### PR TITLE
Deployment and structural corrections

### DIFF
--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -21,6 +21,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 env:
   REGISTRY: ghcr.io
@@ -42,8 +43,75 @@ jobs:
           exit 1
       - run: echo "✅ Deployment confirmed"
 
-  deploy-manual:
+  build-images:
+    # Build + push container images to ghcr tagged with the commit SHA
+    # (mirrors the `images` job in platform-ci.yml).
     needs: validate-confirmation
+    name: Build & push images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - service: core-api
+            context: .
+            dockerfile: Dockerfile
+            project: src/PostyFox.Api.Core/PostyFox.Api.Core.csproj
+            assembly: PostyFox.Api.Core.dll
+          - service: post-api
+            context: .
+            dockerfile: Dockerfile
+            project: src/PostyFox.Api.Post/PostyFox.Api.Post.csproj
+            assembly: PostyFox.Api.Post.dll
+          - service: worker
+            context: .
+            dockerfile: Dockerfile
+            project: src/PostyFox.Worker.Posting/PostyFox.Worker.Posting.csproj
+            assembly: PostyFox.Worker.Posting.dll
+          - service: connectors-node
+            context: src/connectors-node
+            dockerfile: src/connectors-node/Dockerfile
+            project: ""
+            assembly: ""
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.image_tag || github.ref }}
+
+      - name: Determine image tag
+        id: tag
+        run: |
+          if [ -z "${{ github.event.inputs.image_tag }}" ]; then
+            TAG=$(git rev-parse HEAD)
+          else
+            TAG="${{ github.event.inputs.image_tag }}"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Image tag: $TAG"
+
+      - name: Normalize image repository name
+        run: echo "IMAGE_REPOSITORY=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ghcr.io/${{ env.IMAGE_REPOSITORY }}-${{ matrix.service }}:${{ steps.tag.outputs.tag }}
+          build-args: |
+            PROJECT=${{ matrix.project }}
+            ASSEMBLY=${{ matrix.assembly }}
+
+  deploy-manual:
+    needs: [validate-confirmation, build-images]
     name: Deploy ${{ github.event.inputs.environment }}
     runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.environment }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,14 +20,16 @@ Note the comment at the top of the file;
 
 ```
 # PostyFox local stack. Quick start:  docker compose up --build
-# Adds the OIDC edge (Keycloak + oauth2-proxy):  docker compose --profile auth up --build
 #
-# By default the APIs run with Auth__DevMode=true (no login needed) for fast local iteration.
-# The 'auth' profile brings the production-representative oauth2-proxy -> Keycloak path.
+# Auth is the production-representative OIDC path: the stack always runs Keycloak + oauth2-proxy +
+# an nginx gateway, and the APIs validate the OIDC bearer token in-app (no DevMode bypass). Reach the
+# APIs through the edge at  http://localhost:4180  (logs you in via Keycloak on http://localhost:8082).
 ```
 
-You will want to do a docker compose up --build to get the stack running. 
-If you want to test the auth path, you will need to run docker compose --profile auth up --build.
+You will want to do a docker compose up --build to get the stack running.
+Log in and exercise the APIs through the edge at http://localhost:4180 — hitting the APIs directly
+(:8080 / :8081) requires a valid `Authorization: Bearer` token. Note that both of these address are NOT normally exposed
+on "real" deployments.
 
 The auth path includes a full, complete, Keycloak and all parts needed to validate locally without having any
 external dependencies. Credentials which are imported and available for use can be found in the deploy/keycloak 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,10 @@ RUN dotnet publish "$PROJECT" -c Release -o /app --no-restore /p:UseAppHost=fals
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
 WORKDIR /app
+# curl is required by the container healthcheck (not present in the aspnet base image).
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl \
+ && rm -rf /var/lib/apt/lists/*
 COPY --from=build /app .
 ARG ASSEMBLY
 ENV ASSEMBLY=$ASSEMBLY

--- a/README.md
+++ b/README.md
@@ -82,22 +82,22 @@ Transient delivery failures retry with exponential backoff (delayed re-publish) 
 
 ```bash
 cd deploy
-docker compose up --build            # infra + APIs + worker (APIs in DevMode, no login)
-# Core API:  http://localhost:8080    Post API: http://localhost:8081
+docker compose up --build            # full stack incl. the OIDC edge (Keycloak + oauth2-proxy + gateway)
+# Edge (log in here):  http://localhost:4180   → fans out to core-api / post-api after OIDC login
+# Keycloak:            http://localhost:8082
 # Swagger UI: http://localhost:8080/swagger  and  http://localhost:8081/swagger
 # OpenAPI:    http://localhost:8080/openapi/v1.json  (and :8081)
 # RabbitMQ:  http://localhost:15672   MinIO console: http://localhost:9001
 # connectors-node (Bluesky/Tumblr): http://localhost:8090/health
-
-docker compose --profile auth up --build   # adds Keycloak + oauth2-proxy edge
 ```
 
-In DevMode every request is authenticated as `dev-user`. With the `auth` profile, oauth2-proxy
-performs the OIDC exchange against Keycloak and injects the `X-Auth-Request-User` header the APIs
-trust. External/machine callers authenticate with `X-API-Key: <key>` (create one via
-`POST /api/profile/keys`).
+Auth is always the production-representative OIDC path — there is **no DevMode bypass**. oauth2-proxy
+performs the OIDC exchange against Keycloak and the APIs validate the forwarded `Authorization: Bearer`
+token in-app, so reach them through the edge at <http://localhost:4180>. Hitting the APIs directly
+(`:8080`/`:8081`) requires a valid bearer token. External/machine callers authenticate with
+`X-API-Key: <key>` (create one via `POST /api/profile/keys`).
 
-**Browser login (auth profile):** open <http://localhost:4180> and sign in as `postyfox` /
+**Browser login:** open <http://localhost:4180> and sign in as `postyfox` /
 `postyfox` (Keycloak admin console at <http://localhost:8082>, `admin` / `admin`). Keycloak's issuer
 is pinned to `localhost:8082` (`KC_HOSTNAME`) so the browser and the in-cluster back channel stay
 consistent; oauth2-proxy uses split front/back-channel URLs — see
@@ -136,7 +136,8 @@ Telemetry (OTLP) is exported to a collector and forwarded to central **OpenSearc
 ## Configuration (env vars)
 
 Nested keys use `__`. Key settings: `ConnectionStrings__Postgres`, `ObjectStore__*`, `RabbitMq__*`,
-`Secrets__EncryptionKey` (base64 32-byte AES key), `Auth__DevMode`, `Auth__UserHeader`,
+`Secrets__EncryptionKey` (base64 32-byte AES key), `Auth__Oidc__Enabled` / `Auth__Oidc__Issuer` /
+`Auth__Oidc__JwksUrl` / `Auth__Oidc__Audience`, `Auth__UserHeader`,
 `NodeConnectors__BaseUrl` + `NodeConnectors__InternalToken` (→ connectors-node; also set as
 `INTERNAL_TOKEN` on that service), `ApplyMigrations`, `SeedServiceDefinitions`,
 `OTEL_EXPORTER_OTLP_ENDPOINT`.

--- a/deploy/.env.dev.example
+++ b/deploy/.env.dev.example
@@ -22,18 +22,28 @@ RUSTFS_PORT=9000
 RUSTFS_ACCESS_KEY=rustfsadmin
 RUSTFS_SECRET_KEY=rustfsadmin
 
-# External Keycloak
+# External Keycloak — in-cluster back channel (server-side token exchange + JWKS)
 KEYCLOAK_HOST=keycloak.example.com
 KEYCLOAK_PORT=8080
+KEYCLOAK_REALM=PostyFox
+# Browser-facing Keycloak base URL (no trailing slash). MUST equal the token issuer (`iss`).
+KEYCLOAK_PUBLIC_URL=https://auth.dev.example.com
 
 # Internal token for node connectors
 INTERNAL_TOKEN=postyfox-internal-dev-token
 
-# Public-facing host ports
-CORE_API_PORT_START=8080
-CORE_API_PORT_END=8080
-POST_API_PORT_START=8081
-POST_API_PORT_END=8081
+# --- OIDC edge (oauth2-proxy) — the only public entry point ---
+# Public base URL where users reach the edge (used for the OAuth2 callback).
+PUBLIC_BASE_URL=https://app.dev.example.com
+# Confidential client registered in the realm for oauth2-proxy.
+OIDC_CLIENT_ID=oauth2-proxy
+OIDC_CLIENT_SECRET=oauth2-proxy-secret
+# Cookie signing secret — 16/24/32 bytes. Generate with: openssl rand -base64 32
+OAUTH2_PROXY_COOKIE_SECRET=0123456789abcdef0123456789abcdef
+# Host port the edge publishes (front it with your TLS terminator).
+EDGE_PORT=4180
+# Set to false only if the edge is exposed over plain HTTP (no TLS terminator in front).
+EDGE_COOKIE_SECURE=true
 
 # OpenTelemetry endpoint (optional)
 OTEL_ENDPOINT=http://otel-collector:4317

--- a/deploy/.env.prod.example
+++ b/deploy/.env.prod.example
@@ -25,19 +25,29 @@ RUSTFS_PORT=9000
 RUSTFS_ACCESS_KEY=prod_access_key
 RUSTFS_SECRET_KEY=prod_secret_key
 
-# External Keycloak
+# External Keycloak — in-cluster back channel (server-side token exchange + JWKS)
 # Should be on reliable, possibly replicated infrastructure
 KEYCLOAK_HOST=keycloak.prod.internal
 KEYCLOAK_PORT=8080
+KEYCLOAK_REALM=PostyFox
+# Browser-facing Keycloak base URL (no trailing slash). MUST equal the token issuer (`iss`).
+KEYCLOAK_PUBLIC_URL=https://auth.example.com
 
 # Internal token for node connectors (CHANGE IN PRODUCTION!)
 INTERNAL_TOKEN=generate_strong_random_token_min_32_chars
 
-# Public-facing host ports
-CORE_API_PORT_START=9080
-CORE_API_PORT_END=9081
-POST_API_PORT_START=9083
-POST_API_PORT_END=9084
+# --- OIDC edge (oauth2-proxy) — the only public entry point ---
+# Public base URL where users reach the edge (used for the OAuth2 callback).
+PUBLIC_BASE_URL=https://app.example.com
+# Confidential client registered in the realm for oauth2-proxy.
+OIDC_CLIENT_ID=oauth2-proxy
+OIDC_CLIENT_SECRET=generate_from_keycloak_client_credentials
+# Cookie signing secret — 16/24/32 bytes. Generate with: openssl rand -base64 32
+OAUTH2_PROXY_COOKIE_SECRET=generate_strong_key_with_openssl_rand_base64_32
+# Host port the edge publishes; put your TLS terminator / load balancer in front of it.
+EDGE_PORT=4180
+# Keep true in production (TLS terminator in front). Only false for plain-HTTP exposure.
+EDGE_COOKIE_SECURE=true
 
 
 # OpenTelemetry endpoint for production monitoring

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -96,18 +96,14 @@ ssh deploy@server "cd /opt/postyfox/dev && \
 
 ## Ports
 
-The public API ports are configured in each stack's `.env` file:
+Only the OIDC edge (oauth2-proxy) publishes a host port — the APIs, gateway, and connectors-node stay
+on the internal network and are reached through the edge. The edge port is configured per stack in
+`.env`:
 
-- `CORE_API_PORT`
-- `POST_API_PORT`
+- `EDGE_PORT` (default `4180`) — put your TLS terminator / load balancer in front of it.
 
-### Dev Stack
-- Core API: `CORE_API_PORT` (default `8080`)
-- Post API: `POST_API_PORT` (default `8081`)
-
-### Prod Stack
-- Core API: `CORE_API_PORT` (default `9080`)
-- Post API: `POST_API_PORT` (default `9081`)
+All public traffic goes to `http://<host>:${EDGE_PORT}`, which authenticates via Keycloak and
+path-routes `/api/posts` + `/api/webhooks` to post-api and everything else to core-api.
 
 ## External Dependencies
 

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -4,7 +4,7 @@
 # Dev stack:
 # - Uses external Keycloak and RustFS (shared infrastructure)
 # - Isolated Postgres and RabbitMQ per stack/network
-# - Only the public API front ends publish host ports
+# - Only the OIDC edge (oauth2-proxy) publishes a host port; the APIs stay internal
 # - Lighter resource constraints
 
 x-dotnet-env: &dotnet-env
@@ -22,7 +22,6 @@ x-dotnet-env: &dotnet-env
   OTEL_EXPORTER_OTLP_ENDPOINT: "${OTEL_ENDPOINT}"
   OTEL_EXPORTER_OTLP_PROTOCOL: "grpc"
   ASPNETCORE_URLS: "http://+:8080"
-  Auth__DevMode: "false"
 
 services:
   postgres:
@@ -62,13 +61,24 @@ services:
           cpus: '0.5'
           memory: 256M
 
+  # Only the edge publishes a host port; front it with your TLS terminator.
+  oauth2-proxy:
+    ports:
+      - "${EDGE_PORT:-4180}:4180"
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+        reservations:
+          cpus: '0.25'
+          memory: 128M
+
   core-api:
     environment:
       <<: *dotnet-env
       ApplyMigrations: "true"
       SeedServiceDefinitions: "true"
-    ports:
-      - "${CORE_API_PORT_START:-8080}:8080"
     deploy:
       resources:
         limits:
@@ -81,8 +91,6 @@ services:
   post-api:
     environment:
       <<: *dotnet-env
-    ports:
-      - "${POST_API_PORT_START:-8081}:8080"
     deploy:
       resources:
         limits:

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -4,7 +4,7 @@
 # Prod stack:
 # - Uses external Keycloak and RustFS (shared infrastructure)
 # - Isolated Postgres and RabbitMQ per stack/network
-# - Only the public API front ends publish host ports
+# - Only the OIDC edge (oauth2-proxy) publishes a host port; the APIs stay internal
 # - Production resource constraints + restart policies
 # - Health checks and monitoring enabled
 
@@ -23,8 +23,6 @@ x-dotnet-env: &dotnet-env
   OTEL_EXPORTER_OTLP_ENDPOINT: "${OTEL_ENDPOINT}"
   OTEL_EXPORTER_OTLP_PROTOCOL: "grpc"
   ASPNETCORE_URLS: "http://+:8080"
-  # Enable security hardening for prod
-  Auth__DevMode: "false"
 
 services:
   postgres:
@@ -65,6 +63,20 @@ services:
           cpus: '1'
           memory: 512M
 
+  # Only the edge publishes a host port; front it with your TLS terminator / load balancer. The APIs
+  # are reached internally (compose DNS round-robins across replicas), so no per-replica port ranges.
+  oauth2-proxy:
+    ports:
+      - "${EDGE_PORT:-4180}:4180"
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 512M
+        reservations:
+          cpus: '0.5'
+          memory: 256M
+
   core-api:
     environment:
       <<: *dotnet-env
@@ -72,9 +84,6 @@ services:
       SeedServiceDefinitions: "false"
       RateLimit__Enabled: "true"
       RateLimit__RequestsPerMinute: "300"
-    ports:
-      # Reserve one host port per replica (e.g. 9080, 9081 for 2 replicas)
-      - "${CORE_API_PORT_START:-9080}-${CORE_API_PORT_END:-9081}:8080"
     deploy:
       resources:
         limits:
@@ -89,9 +98,6 @@ services:
       <<: *dotnet-env
       RateLimit__Enabled: "true"
       RateLimit__RequestsPerMinute: "300"
-    ports:
-      # Reserve one host port per replica (e.g. 9082, 9083 for 2 replicas)
-      - "${POST_API_PORT_START:-9082}-${POST_API_PORT_END:-9083}:8080"
     deploy:
       replicas: 2
       resources:

--- a/deploy/docker-compose.server.yml
+++ b/deploy/docker-compose.server.yml
@@ -3,8 +3,9 @@
 #
 # - App services use prebuilt images from GHCR.
 # - Postgres and RabbitMQ run per stack on the server.
-# - RustFS and auth are provided externally.
-# - Only the API front ends should publish host ports via env-specific overrides.
+# - RustFS and Keycloak are provided externally.
+# - The OIDC edge (oauth2-proxy) is the ONLY service that publishes a public host port (via the
+#   env-specific overrides); the APIs, gateway, and connectors-node stay on the internal network.
 
 x-dotnet-env: &dotnet-env
   ConnectionStrings__Postgres: "Host=postgres;Port=5432;Database=postyfox;Username=postyfox;Password=${DB_PASSWORD}"
@@ -16,8 +17,15 @@ x-dotnet-env: &dotnet-env
   RabbitMq__User: "${RABBITMQ_USER}"
   RabbitMq__Password: "${RABBITMQ_PASSWORD}"
   Secrets__EncryptionKey: "${SECRETS_ENCRYPTION_KEY}"
-  Auth__DevMode: "false"
   Auth__UserHeader: "${AUTH_USER_HEADER:-X-Auth-Request-User}"
+  # In-app OIDC bearer validation: the edge forwards the validated token, the APIs re-validate it.
+  # This MUST be enabled — the APIs trust NO injected identity header, only the OIDC bearer / API key.
+  # Issuer = the browser-facing Keycloak URL (token `iss`); JWKS is fetched over the in-cluster back
+  # channel — mirrors the oauth2-proxy split below.
+  Auth__Oidc__Enabled: "true"
+  Auth__Oidc__Issuer: "${KEYCLOAK_PUBLIC_URL}/realms/${KEYCLOAK_REALM:-PostyFox}"
+  Auth__Oidc__JwksUrl: "http://${KEYCLOAK_HOST}:${KEYCLOAK_PORT:-8080}/realms/${KEYCLOAK_REALM:-PostyFox}/protocol/openid-connect/certs"
+  Auth__Oidc__Audience: "${OIDC_CLIENT_ID:-oauth2-proxy}"
   NodeConnectors__BaseUrl: "http://connectors-node:8090"
   NodeConnectors__InternalToken: "${INTERNAL_TOKEN}"
   OTEL_EXPORTER_OTLP_ENDPOINT: "${OTEL_ENDPOINT:-http://otel-collector:4317}"
@@ -94,7 +102,10 @@ services:
       test: ["CMD-SHELL", "curl -fsS http://localhost:8080/healthz | grep -q '\"status\":\"ok\"'"]
       interval: 5s
       timeout: 3s
-      retries: 20      
+      retries: 20
+      # core-api applies DB migrations + seeding before Kestrel starts listening, so allow a
+      # grace window before failing probes count against the retry budget.
+      start_period: 30s
     restart: unless-stopped
 
   post-api:
@@ -127,6 +138,59 @@ services:
       interval: 5s
       timeout: 3s
       retries: 20
+    restart: unless-stopped
+
+  # Internal path router behind the edge. Fans /api/posts + /api/webhooks to post-api and everything
+  # else to core-api, preserving the full request path. Never publishes a host port.
+  gateway:
+    image: nginx:alpine
+    volumes:
+      - ./gateway/nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      core-api: { condition: service_healthy }
+      post-api: { condition: service_healthy }
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost/healthz || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+    restart: unless-stopped
+
+  # The OIDC edge — the ONLY service that should publish a public port (done in the env overrides).
+  # Configured entirely via OAUTH2_PROXY_* env vars (no config file). Split front/back-channel:
+  #   - browser redirects use KEYCLOAK_PUBLIC_URL (the token `iss`)
+  #   - server-side token/JWKS use the in-cluster KEYCLOAK_HOST back channel
+  oauth2-proxy:
+    image: quay.io/oauth2-proxy/oauth2-proxy:latest
+    environment:
+      OAUTH2_PROXY_HTTP_ADDRESS: "0.0.0.0:4180"
+      OAUTH2_PROXY_PROVIDER: "oidc"
+      OAUTH2_PROXY_SKIP_OIDC_DISCOVERY: "true"
+      OAUTH2_PROXY_OIDC_ISSUER_URL: "${KEYCLOAK_PUBLIC_URL}/realms/${KEYCLOAK_REALM:-PostyFox}"
+      OAUTH2_PROXY_LOGIN_URL: "${KEYCLOAK_PUBLIC_URL}/realms/${KEYCLOAK_REALM:-PostyFox}/protocol/openid-connect/auth"
+      OAUTH2_PROXY_REDEEM_URL: "http://${KEYCLOAK_HOST}:${KEYCLOAK_PORT:-8080}/realms/${KEYCLOAK_REALM:-PostyFox}/protocol/openid-connect/token"
+      OAUTH2_PROXY_OIDC_JWKS_URL: "http://${KEYCLOAK_HOST}:${KEYCLOAK_PORT:-8080}/realms/${KEYCLOAK_REALM:-PostyFox}/protocol/openid-connect/certs"
+      OAUTH2_PROXY_CLIENT_ID: "${OIDC_CLIENT_ID:-oauth2-proxy}"
+      OAUTH2_PROXY_CLIENT_SECRET: "${OIDC_CLIENT_SECRET}"
+      OAUTH2_PROXY_COOKIE_SECRET: "${OAUTH2_PROXY_COOKIE_SECRET}"
+      OAUTH2_PROXY_EMAIL_DOMAINS: "*"
+      OAUTH2_PROXY_REDIRECT_URL: "${PUBLIC_BASE_URL}/oauth2/callback"
+      # Single root upstream → the internal nginx gateway (which does the path routing).
+      OAUTH2_PROXY_UPSTREAMS: "http://gateway:80/"
+      # Anonymous, HMAC-signed inbound webhook — external senders can't do an OIDC login.
+      OAUTH2_PROXY_SKIP_AUTH_ROUTES: "POST=^/api/webhooks/"
+      # Forward the validated ID token to upstreams as `Authorization: Bearer` (APIs re-validate it).
+      OAUTH2_PROXY_PASS_AUTHORIZATION_HEADER: "true"
+      OAUTH2_PROXY_PASS_ACCESS_TOKEN: "true"
+      OAUTH2_PROXY_SKIP_PROVIDER_BUTTON: "true"
+      # Sits behind a TLS-terminating reverse proxy on the host; trust X-Forwarded-* and set secure
+      # cookies (set EDGE_COOKIE_SECURE=false only if you expose the edge over plain HTTP).
+      OAUTH2_PROXY_REVERSE_PROXY: "true"
+      OAUTH2_PROXY_COOKIE_SECURE: "${EDGE_COOKIE_SECURE:-true}"
+    depends_on:
+      gateway: { condition: service_healthy }
+      core-api: { condition: service_healthy }
+      post-api: { condition: service_healthy }
     restart: unless-stopped
 
 volumes:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,8 +1,9 @@
 # PostyFox local stack. Quick start:  docker compose up --build
-# Adds the OIDC edge (Keycloak + oauth2-proxy):  docker compose --profile auth up --build
 #
-# By default the APIs run with Auth__DevMode=true (no login needed) for fast local iteration.
-# The 'auth' profile brings the production-representative oauth2-proxy -> Keycloak path.
+# Auth is the production-representative OIDC path: the stack always runs Keycloak + oauth2-proxy +
+# an nginx gateway, and the APIs validate the OIDC bearer token in-app (no DevMode bypass). Reach the
+# APIs through the edge at  http://localhost:4180  (which logs you in via Keycloak on http://localhost:8082
+# and fans out to core-api/post-api). Hitting the APIs directly (:8080/:8081) requires a valid bearer.
 name: postyfox
 
 x-dotnet-env: &dotnet-env
@@ -15,8 +16,13 @@ x-dotnet-env: &dotnet-env
   RabbitMq__User: "guest"
   RabbitMq__Password: "guest"
   Secrets__EncryptionKey: "cG9zdHlmb3gtZGV2LXNlY3JldC1rZXktMzJieXRlcyE="
-  Auth__DevMode: "true"
   Auth__UserHeader: "X-Auth-Request-User"
+  # In-app OIDC bearer validation. Issuer is the browser-facing Keycloak URL (matches the token `iss`);
+  # JWKS is fetched over the in-cluster back channel (mirrors the oauth2-proxy split front/back-channel).
+  Auth__Oidc__Enabled: "true"
+  Auth__Oidc__Issuer: "http://localhost:8082/realms/PostyFox"
+  Auth__Oidc__JwksUrl: "http://keycloak:8080/realms/PostyFox/protocol/openid-connect/certs"
+  Auth__Oidc__Audience: "oauth2-proxy"
   NodeConnectors__BaseUrl: "http://connectors-node:8090"
   NodeConnectors__InternalToken: "postyfox-internal-dev-token"
   OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
@@ -111,6 +117,9 @@ services:
       interval: 5s
       timeout: 3s
       retries: 20
+      # core-api applies DB migrations + seeding before Kestrel starts listening, so allow a
+      # grace window before failing probes count against the retry budget.
+      start_period: 30s
     depends_on:
       postgres: { condition: service_healthy }
       rabbitmq: { condition: service_healthy }
@@ -148,11 +157,6 @@ services:
         ASSEMBLY: PostyFox.Worker.Posting.dll
     environment:
       <<: *dotnet-env
-    healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://localhost:8080/healthz | grep -q '\"status\":\"ok\"'"]
-      interval: 5s
-      timeout: 3s
-      retries: 20
     depends_on:
       postgres: { condition: service_healthy }
       rabbitmq: { condition: service_healthy }
@@ -177,7 +181,6 @@ services:
       KC_HOSTNAME: "http://localhost:8082"
     volumes: ["./keycloak:/opt/keycloak/data/import:ro"]
     ports: ["8082:8080"]
-    profiles: ["auth"]
     # The image has no curl/wget but does have bash; a /dev/tcp probe confirms the HTTP port is
     # accepting connections (Keycloak binds 8080 only at the end of boot, after realm import).
     healthcheck:
@@ -186,6 +189,15 @@ services:
       timeout: 5s
       retries: 30
       start_period: 20s
+
+  # Internal path router behind oauth2-proxy. Fans /api/posts + /api/webhooks to post-api and
+  # everything else to core-api, preserving the full request path. Not published publicly.
+  gateway:
+    image: nginx:alpine
+    volumes: ["./gateway/nginx.conf:/etc/nginx/nginx.conf:ro"]
+    depends_on:
+      core-api: { condition: service_healthy }
+      post-api: { condition: service_healthy }
 
   oauth2-proxy:
     image: quay.io/oauth2-proxy/oauth2-proxy:latest
@@ -196,9 +208,8 @@ services:
     # wait for Keycloak to be healthy; restart is a safety net for the brief realm-readiness window.
     depends_on:
       keycloak: { condition: service_healthy }
-      core-api: { condition: service_healthy }
+      gateway: { condition: service_started }
     restart: unless-stopped
-    profiles: ["auth"]
 
 volumes:
   pgdata:

--- a/deploy/gateway/nginx.conf
+++ b/deploy/gateway/nginx.conf
@@ -1,0 +1,16 @@
+# Internal path router sitting behind oauth2-proxy: fans /api/posts + /api/webhooks to post-api
+# and everything else to core-api, preserving the full request path (which oauth2-proxy's
+# sub-path upstreams do not). Not published — only oauth2-proxy is the public route.
+events {}
+http {
+  upstream core { server core-api:8080; }
+  upstream post { server post-api:8080; }
+  server {
+    listen 80;
+    # Gateway's own liveness (for the container healthcheck) — not routed to a backend.
+    location = /healthz { access_log off; return 200 "ok\n"; }
+    location /api/posts    { proxy_pass http://post; }
+    location /api/webhooks { proxy_pass http://post; }
+    location /             { proxy_pass http://core; }
+  }
+}

--- a/deploy/helm/postyfox/templates/configmap.yaml
+++ b/deploy/helm/postyfox/templates/configmap.yaml
@@ -8,8 +8,13 @@ data:
   ObjectStore__Bucket: {{ .Values.config.objectStoreBucket | quote }}
   RabbitMq__Host: {{ .Values.config.rabbitMqHost | quote }}
   RabbitMq__User: {{ .Values.config.rabbitMqUser | quote }}
-  Auth__DevMode: {{ .Values.config.authDevMode | quote }}
   Auth__UserHeader: {{ .Values.config.authUserHeader | quote }}
+  # In-app OIDC bearer validation (defence-in-depth): the edge forwards the token, the APIs re-validate
+  # it. The APIs trust no injected header, so this MUST be enabled or they reject every request.
+  Auth__Oidc__Enabled: {{ .Values.config.authOidcEnabled | quote }}
+  Auth__Oidc__Issuer: {{ .Values.config.authOidcIssuer | quote }}
+  Auth__Oidc__JwksUrl: {{ .Values.config.authOidcJwksUrl | quote }}
+  Auth__Oidc__Audience: {{ .Values.config.authOidcAudience | quote }}
   NodeConnectors__BaseUrl: "http://{{ include "postyfox.fullname" . }}-connectors-node:8090"
   OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.config.otelEndpoint | quote }}
   OTEL_EXPORTER_OTLP_PROTOCOL: "grpc"

--- a/deploy/helm/postyfox/templates/core-api.yaml
+++ b/deploy/helm/postyfox/templates/core-api.yaml
@@ -35,5 +35,7 @@ metadata:
   name: {{ include "postyfox.fullname" . }}-core-api
   labels: {{- include "postyfox.labels" . | nindent 4 }}
 spec:
+  # Internal only — reached via the OIDC edge, never exposed publicly. Do not change to LoadBalancer.
+  type: ClusterIP
   selector: { app.kubernetes.io/name: postyfox-core-api }
   ports: [{ port: 8080, targetPort: 8080 }]

--- a/deploy/helm/postyfox/templates/ingress.yaml
+++ b/deploy/helm/postyfox/templates/ingress.yaml
@@ -1,8 +1,10 @@
 {{- if .Values.ingress.enabled }}
+# Fronts the OIDC edge ONLY. core-api/post-api are ClusterIP and intentionally have no rule here —
+# exposing them directly would bypass authentication at the network layer. See values.yaml.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "postyfox.fullname" . }}
+  name: {{ include "postyfox.fullname" . }}-edge
   labels: {{- include "postyfox.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations: {{- toYaml . | nindent 4 }}
@@ -15,16 +17,10 @@ spec:
   tls: {{- toYaml . | nindent 4 }}
   {{- end }}
   rules:
-    - host: {{ .Values.ingress.coreApiHost }}
+    - host: {{ .Values.ingress.host }}
       http:
         paths:
           - path: /
             pathType: Prefix
-            backend: { service: { name: {{ include "postyfox.fullname" . }}-core-api, port: { number: 8080 } } }
-    - host: {{ .Values.ingress.postApiHost }}
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend: { service: { name: {{ include "postyfox.fullname" . }}-post-api, port: { number: 8080 } } }
+            backend: { service: { name: {{ .Values.ingress.edgeServiceName }}, port: { number: {{ .Values.ingress.edgePort }} } } }
 {{- end }}

--- a/deploy/helm/postyfox/templates/post-api.yaml
+++ b/deploy/helm/postyfox/templates/post-api.yaml
@@ -32,5 +32,7 @@ metadata:
   name: {{ include "postyfox.fullname" . }}-post-api
   labels: {{- include "postyfox.labels" . | nindent 4 }}
 spec:
+  # Internal only — reached via the OIDC edge, never exposed publicly. Do not change to LoadBalancer.
+  type: ClusterIP
   selector: { app.kubernetes.io/name: postyfox-post-api }
   ports: [{ port: 8080, targetPort: 8080 }]

--- a/deploy/helm/postyfox/values.yaml
+++ b/deploy/helm/postyfox/values.yaml
@@ -9,12 +9,17 @@ imagePullSecrets: []
 # Backing services (PostgreSQL, RabbitMQ, S3/object store) are expected to be provided externally
 # (managed services or separate charts). Only their connection details are configured here.
 config:
-  objectStoreServiceUrl: "http://minio:9000"
+  objectStoreServiceUrl: "http://rustfs:9000"   # any S3-compatible endpoint (RustFS/MinIO/managed S3)
   objectStoreBucket: "postyfox"
   rabbitMqHost: "rabbitmq"
   rabbitMqUser: "guest"
-  authDevMode: "false"
   authUserHeader: "X-Auth-Request-User"
+  # In-app OIDC bearer validation. The APIs trust NO injected header — only the validated JWT the
+  # edge forwards (or an API key). This MUST stay enabled. Point issuer/JWKS at your Keycloak.
+  authOidcEnabled: "true"
+  authOidcIssuer: "https://keycloak.example/realms/PostyFox"
+  authOidcJwksUrl: "https://keycloak.example/realms/PostyFox/protocol/openid-connect/certs"
+  authOidcAudience: "oauth2-proxy"
   otelEndpoint: "http://otel-collector:4317"
 
 # Secret values. In production, source these from a secret manager (External Secrets / Sealed
@@ -45,10 +50,17 @@ resources:
   requests: { cpu: "100m", memory: "128Mi" }
   limits: { cpu: "1", memory: "512Mi" }
 
+# SECURITY — exposure model: only the OIDC edge (oauth2-proxy) may be publicly reachable. The
+# core-api/post-api/connectors-node Services are ClusterIP (internal) and must NEVER be given a
+# public Ingress or LoadBalancer. This Ingress fronts the edge only.
+#
+# NB: this chart does not yet package the OIDC edge itself (oauth2-proxy + Keycloak) — deploy it
+# separately (or as a follow-up, add it here) and point `edgeServiceName` at its in-cluster Service.
 ingress:
   enabled: false
   className: ""
   annotations: {}
-  coreApiHost: api.postyfox.example
-  postApiHost: post.postyfox.example
+  host: postyfox.example        # single public host → the OIDC edge
+  edgeServiceName: oauth2-proxy # in-cluster Service name of the OIDC edge (NOT an API service)
+  edgePort: 4180
   tls: []

--- a/deploy/keycloak/postyfox-realm.json
+++ b/deploy/keycloak/postyfox-realm.json
@@ -9,6 +9,7 @@
       "publicClient": false,
       "secret": "oauth2-proxy-secret",
       "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
       "redirectUris": ["http://localhost:4180/oauth2/callback"],
       "webOrigins": ["http://localhost:4180"]
     }

--- a/deploy/oauth2-proxy/oauth2-proxy.cfg
+++ b/deploy/oauth2-proxy/oauth2-proxy.cfg
@@ -19,11 +19,24 @@ client_id = "oauth2-proxy"
 client_secret = "oauth2-proxy-secret"
 cookie_secret = "0123456789abcdef0123456789abcdef"
 email_domains = ["*"]
-upstreams = ["http://core-api:8080"]
 redirect_url = "http://localhost:4180/oauth2/callback"
 
-# Pass the authenticated identity to the upstream API.
+# The edge fronts BOTH APIs. A single root upstream is used (which preserves the full request path)
+# pointing at an internal nginx gateway that path-routes to the two backends: post-api owns
+# /api/posts and /api/webhooks, core-api is the catch-all. (oauth2-proxy's own sub-path upstreams
+# rewrite the request to the mount path and drop the remainder, so the gateway does the routing.)
+# The APIs and the gateway are not published publicly in a real deployment — the proxy is the only
+# public route.
+upstreams = ["http://gateway:80/"]
+
+# The inbound webhook is anonymous (HMAC-signed) — external senders can't do an OIDC login, so skip
+# auth for it (post-api still verifies the signature).
+skip_auth_routes = ["POST=^/api/webhooks/"]
+
+# Forward the validated OIDC ID token to the upstream as `Authorization: Bearer` so the APIs can
+# validate it themselves (defence-in-depth) rather than trusting an injected identity header.
+# NB: pass_authorization_header (upstream request) — NOT set_authorization_header (which only sets
+# the header on the response, for nginx auth_request mode).
+pass_authorization_header = true
 pass_access_token = true
-set_xauthrequest = true
-pass_user_headers = true
 skip_provider_button = true

--- a/deploy/terraform-aca/main.tf
+++ b/deploy/terraform-aca/main.tf
@@ -19,8 +19,11 @@ locals {
     { name = "ObjectStore__Bucket", value = var.object_store_bucket },
     { name = "RabbitMq__Host", value = var.rabbitmq_host },
     { name = "RabbitMq__User", value = var.rabbitmq_user },
-    { name = "Auth__DevMode", value = "false" },
     { name = "Auth__UserHeader", value = "X-Auth-Request-User" },
+    { name = "Auth__Oidc__Enabled", value = "true" },
+    { name = "Auth__Oidc__Issuer", value = var.auth_oidc_issuer },
+    { name = "Auth__Oidc__JwksUrl", value = var.auth_oidc_jwks_url },
+    { name = "Auth__Oidc__Audience", value = var.auth_oidc_audience },
     { name = "OTEL_EXPORTER_OTLP_ENDPOINT", value = var.otel_endpoint },
     { name = "OTEL_EXPORTER_OTLP_PROTOCOL", value = "grpc" },
     { name = "ASPNETCORE_URLS", value = "http://+:8080" },
@@ -138,7 +141,7 @@ resource "azurerm_container_app" "connectors_node" {
   }
 }
 
-# --- core-api (external ingress, owns migrations) ---
+# --- core-api (internal ingress, owns migrations) ---
 resource "azurerm_container_app" "core_api" {
   name                         = "postyfox-core-api"
   container_app_environment_id = azurerm_container_app_environment.this.id
@@ -191,8 +194,10 @@ resource "azurerm_container_app" "core_api" {
     }
   }
 
+  # Internal only. Public access goes through the OIDC edge; the APIs are never externally exposed
+  # (they re-validate the forwarded JWT in-app). Provisioning the edge is a follow-up — see README.
   ingress {
-    external_enabled = true
+    external_enabled = false
     target_port      = 8080
     traffic_weight {
       latest_revision = true
@@ -201,7 +206,7 @@ resource "azurerm_container_app" "core_api" {
   }
 }
 
-# --- post-api (external ingress) ---
+# --- post-api (internal ingress) ---
 resource "azurerm_container_app" "post_api" {
   name                         = "postyfox-post-api"
   container_app_environment_id = azurerm_container_app_environment.this.id
@@ -250,8 +255,9 @@ resource "azurerm_container_app" "post_api" {
     }
   }
 
+  # Internal only — see core-api. The OIDC edge is the sole external Container App.
   ingress {
-    external_enabled = true
+    external_enabled = false
     target_port      = 8080
     traffic_weight {
       latest_revision = true

--- a/deploy/terraform-aca/terraform.tfvars.example
+++ b/deploy/terraform-aca/terraform.tfvars.example
@@ -8,6 +8,11 @@ object_store_service_url = "https://<account>.blob.core.windows.net"
 rabbitmq_host            = "my-rabbit.example.com"
 otel_endpoint            = "http://otel-collector:4317"
 
+# In-app OIDC bearer validation (the APIs are internal; the OIDC edge forwards the token).
+auth_oidc_issuer   = "https://keycloak.example/realms/PostyFox"
+auth_oidc_jwks_url = "https://keycloak.example/realms/PostyFox/protocol/openid-connect/certs"
+auth_oidc_audience = "oauth2-proxy"
+
 # Secrets — supply via TF_VAR_* env vars in CI, not this file.
 postgres_connection     = "Host=...;Port=5432;Database=postyfox;Username=...;Password=..."
 encryption_key          = "<base64-32-bytes>"

--- a/deploy/terraform-aca/variables.tf
+++ b/deploy/terraform-aca/variables.tf
@@ -48,6 +48,21 @@ variable "otel_endpoint" {
   default = ""
 }
 
+# In-app OIDC bearer validation. DevMode does not exist in ACA, so the APIs trust the validated JWT
+# the OIDC edge forwards (not any header). Point these at your Keycloak realm.
+variable "auth_oidc_issuer" {
+  type        = string
+  description = "OIDC issuer (token `iss`), e.g. https://keycloak.example/realms/PostyFox"
+}
+variable "auth_oidc_jwks_url" {
+  type        = string
+  description = "JWKS URL for signing-key validation."
+}
+variable "auth_oidc_audience" {
+  type    = string
+  default = "oauth2-proxy"
+}
+
 # Secrets
 variable "postgres_connection" {
   type      = string

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,7 +34,7 @@ event arrives. This repo is the backend + infrastructure only (the control-panel
 ```mermaid
 flowchart TB
     client["Client / control panel"]
-    edge["Ingress: oauth2-proxy<br/>(OIDC → Keycloak)<br/>[auth profile]"]
+    edge["Edge: oauth2-proxy<br/>(OIDC → Keycloak)<br/>+ nginx gateway fan-out"]
 
     subgraph apps["PostyFox services (containers)"]
         core["core-api (C#)<br/>profile/keys, services,<br/>connectors, templates, triggers"]
@@ -231,15 +231,19 @@ Notes:
 flowchart LR
     req["Incoming request"] --> policy{"X-API-Key present?"}
     policy -- yes --> apik["ApiKey scheme<br/>validate hash → userId"]
-    policy -- no --> hdr["Header scheme<br/>X-Auth-Request-User → userId<br/>(DevMode → dev-user)"]
-    apik & hdr --> claims["ClaimsPrincipal<br/>(NameIdentifier = userId)"]
+    policy -- "no, Bearer + OIDC on" --> jwt["JWT scheme<br/>validate OIDC token (JWKS)<br/>sub → userId"]
+    policy -- otherwise --> hdr["Header scheme<br/>(DevMode → dev-user; else reject)"]
+    apik & jwt & hdr --> claims["ClaimsPrincipal<br/>(NameIdentifier = userId)"]
 ```
 
-- A **policy scheme** (`PostyFox`) forwards to one of two handlers based on the presence of the
-  `X-API-Key` header.
-- **Header scheme** trusts the identity header injected by the oauth2-proxy edge (which performs the
-  OIDC exchange against Keycloak). `Auth:DevMode=true` authenticates every request as `Auth:DevUserId`
-  for local iteration.
+- A **policy scheme** (`PostyFox`) forwards by credential: `X-API-Key` → ApiKey; else an
+  `Authorization: Bearer` token (when OIDC is enabled) → JWT; otherwise the Header scheme.
+- **JWT scheme** validates the OIDC bearer token the oauth2-proxy edge forwards, in-app, against the
+  realm's JWKS (issuer + lifetime + optional audience). This is the production path — the APIs trust
+  **no** injected identity header.
+- **Header scheme** authenticates as `Auth:DevUserId` only when `Auth:DevMode=true` (a test-only
+  in-process switch; no shipped configuration enables it). Otherwise it rejects — a raw
+  `X-Auth-Request-User` header is never trusted.
 - **API-key scheme** validates the presented key against a PBKDF2 hash (constant-time), for
   external/machine callers — the retained requirement. Keys are prefix-indexed; the secret is never
   stored.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -54,14 +54,17 @@ is an in-memory scheduler; a durable due-scan is a future item for very long hor
 **Context.** The legacy trusted platform-injected identity headers (EasyAuth). We need equivalent
 OIDC auth that is portable, plus machine-to-machine access.
 
-**Decision.** An oauth2-proxy ingress performs the OIDC exchange (Keycloak) and injects a trusted
-identity header the APIs consume — preserving the header-trust model while moving the trust boundary
-to a component we deploy everywhere. **API keys are retained** for external connectivity, stored as
-PBKDF2 hashes (never in clear) and verified in constant time.
+**Decision.** An oauth2-proxy edge performs the OIDC exchange (Keycloak) and forwards the validated
+token to the APIs as `Authorization: Bearer`; the APIs **re-validate it in-app** against the realm's
+JWKS rather than trusting an injected identity header. An internal nginx gateway path-routes the edge
+to core-api/post-api. **API keys are retained** for external connectivity, stored as PBKDF2 hashes
+(never in clear) and verified in constant time. There is no DevMode bypass in any deployment — local
+dev runs the same Keycloak edge.
 
-**Trade-off.** APIs trust an upstream header, so the edge must be correctly fronting them (or use the
-`auth` profile locally / DevMode for dev). In-app JWT validation is a viable alternative hardening
-step. Fixing the legacy's non-comparing API-key check was a requirement.
+**Trade-off.** The APIs depend on OIDC config (issuer/JWKS) being correct, and local dev now requires
+Keycloak to be up (no header/DevMode shortcut) — but the trust boundary no longer relies on a
+spoofable header, and local mirrors production. Fixing the legacy's non-comparing API-key check was a
+requirement.
 
 ---
 

--- a/src/PostyFox.Api.Core/appsettings.Development.json
+++ b/src/PostyFox.Api.Core/appsettings.Development.json
@@ -1,8 +1,12 @@
 {
   "ApplyMigrations": true,
   "Auth": {
-    "DevMode": true,
-    "DevUserId": "dev-user"
+    "Oidc": {
+      "Enabled": true,
+      "Issuer": "http://localhost:8082/realms/PostyFox",
+      "JwksUrl": "http://localhost:8082/realms/PostyFox/protocol/openid-connect/certs",
+      "Audience": "oauth2-proxy"
+    }
   },
   "SeedServiceDefinitions": true
 }

--- a/src/PostyFox.Api.Core/appsettings.json
+++ b/src/PostyFox.Api.Core/appsettings.json
@@ -7,7 +7,7 @@
   "ConnectionStrings": {
     "Postgres": "Host=localhost;Port=5432;Database=postyfox;Username=postyfox;Password=postyfox"
   },
-  "Auth": { "DevMode": false, "UserHeader": "X-Auth-Request-User" },
+  "Auth": { "UserHeader": "X-Auth-Request-User", "Oidc": { "Enabled": false } },
   "ObjectStore": { "ServiceUrl": "http://localhost:9000", "AccessKey": "minioadmin", "SecretKey": "minioadmin", "Bucket": "postyfox" },
   "RabbitMq": { "Host": "localhost", "Port": 5672, "User": "guest", "Password": "guest" },
   "Secrets": { "EncryptionKey": "" }

--- a/src/PostyFox.Api.Post/appsettings.Development.json
+++ b/src/PostyFox.Api.Post/appsettings.Development.json
@@ -1,3 +1,10 @@
 {
-  "Auth": { "DevMode": true, "DevUserId": "dev-user" }
+  "Auth": {
+    "Oidc": {
+      "Enabled": true,
+      "Issuer": "http://localhost:8082/realms/PostyFox",
+      "JwksUrl": "http://localhost:8082/realms/PostyFox/protocol/openid-connect/certs",
+      "Audience": "oauth2-proxy"
+    }
+  }
 }

--- a/src/PostyFox.Api.Post/appsettings.json
+++ b/src/PostyFox.Api.Post/appsettings.json
@@ -7,7 +7,7 @@
   "ConnectionStrings": {
     "Postgres": "Host=localhost;Port=5432;Database=postyfox;Username=postyfox;Password=postyfox"
   },
-  "Auth": { "DevMode": false, "UserHeader": "X-Auth-Request-User" },
+  "Auth": { "UserHeader": "X-Auth-Request-User", "Oidc": { "Enabled": false } },
   "ObjectStore": { "ServiceUrl": "http://localhost:9000", "AccessKey": "minioadmin", "SecretKey": "minioadmin", "Bucket": "postyfox" },
   "RabbitMq": { "Host": "localhost", "Port": 5672, "User": "guest", "Password": "guest" },
   "Secrets": { "EncryptionKey": "" }

--- a/src/PostyFox.Web/Auth/AuthConstants.cs
+++ b/src/PostyFox.Web/Auth/AuthConstants.cs
@@ -5,5 +5,6 @@ public static class AuthConstants
     public const string PolicyScheme = "PostyFox";
     public const string Header = "Header";
     public const string ApiKey = "ApiKey";
+    public const string Jwt = "Jwt";
     public const string ApiKeyHeader = "X-API-Key";
 }

--- a/src/PostyFox.Web/Auth/HeaderAuthenticationHandler.cs
+++ b/src/PostyFox.Web/Auth/HeaderAuthenticationHandler.cs
@@ -7,8 +7,12 @@ using Microsoft.Extensions.Options;
 namespace PostyFox.Web.Auth;
 
 /// <summary>
-/// Trusts the identity header injected by the oauth2-proxy ingress (which performs the OIDC
-/// exchange against Keycloak). In DevMode, authenticates as a fixed dev user.
+/// DevMode-only local authentication: authenticates every request as a fixed dev user.
+///
+/// IMPORTANT: this does NOT trust <c>X-Auth-Request-User</c> outside DevMode. A raw identity header
+/// is spoofable by anything that can reach the API directly, so production auth uses the validated
+/// OIDC bearer token (<see cref="AuthConstants.Jwt"/>) or an API key instead. The OIDC edge must be
+/// the only public route and must forward the bearer token to the upstream APIs.
 /// </summary>
 public sealed class HeaderAuthenticationHandler(
     IOptionsMonitor<AuthenticationSchemeOptions> options,
@@ -21,19 +25,11 @@ public sealed class HeaderAuthenticationHandler(
 
     protected override Task<AuthenticateResult> HandleAuthenticateAsync()
     {
-        string? userId;
-        if (_auth.DevMode)
-        {
-            userId = _auth.DevUserId;
-        }
-        else
-        {
-            userId = Request.Headers.TryGetValue(_auth.UserHeader, out var v) ? v.ToString() : null;
-            if (string.IsNullOrWhiteSpace(userId))
-                return Task.FromResult(AuthenticateResult.NoResult());
-        }
+        if (!_auth.DevMode)
+            return Task.FromResult(AuthenticateResult.NoResult());
 
-        var claims = new List<Claim> { new(ClaimTypes.NameIdentifier, userId!) };
+        var userId = _auth.DevUserId;
+        var claims = new List<Claim> { new(ClaimTypes.NameIdentifier, userId) };
         if (_auth.EmailHeader is { } eh && Request.Headers.TryGetValue(eh, out var email) && !string.IsNullOrEmpty(email))
             claims.Add(new Claim(ClaimTypes.Email, email!));
 

--- a/src/PostyFox.Web/Auth/JwtValidation.cs
+++ b/src/PostyFox.Web/Auth/JwtValidation.cs
@@ -1,0 +1,71 @@
+using System.Collections.Concurrent;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+
+namespace PostyFox.Web.Auth;
+
+/// <summary>Fetches and caches OIDC signing keys (JWKS) from a back-channel-reachable URL.</summary>
+public interface IJwksProvider
+{
+    IReadOnlyCollection<SecurityKey> GetSigningKeys(string jwksUrl);
+}
+
+public sealed class CachedJwksProvider(IHttpClientFactory httpFactory, ILogger<CachedJwksProvider> logger) : IJwksProvider
+{
+    private static readonly TimeSpan Ttl = TimeSpan.FromMinutes(10);
+    private readonly ConcurrentDictionary<string, (DateTimeOffset fetched, IReadOnlyCollection<SecurityKey> keys)> _cache = new();
+
+    public IReadOnlyCollection<SecurityKey> GetSigningKeys(string jwksUrl)
+    {
+        if (_cache.TryGetValue(jwksUrl, out var cached) && DateTimeOffset.UtcNow - cached.fetched < Ttl)
+            return cached.keys;
+
+        try
+        {
+            var client = httpFactory.CreateClient("jwks");
+            var json = client.GetStringAsync(jwksUrl).GetAwaiter().GetResult();
+            IReadOnlyCollection<SecurityKey> keys = JsonWebKeySet.Create(json).GetSigningKeys().ToList();
+            _cache[jwksUrl] = (DateTimeOffset.UtcNow, keys);
+            return keys;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to fetch JWKS from {Url}", jwksUrl);
+            // Serve stale keys if we have them; otherwise none (token validation will fail closed).
+            return cached.keys ?? [];
+        }
+    }
+}
+
+/// <summary>
+/// Configures the JwtBearer scheme from <see cref="PostyFoxAuthOptions.Oidc"/> at options-resolution
+/// time (so test/host-injected config is honoured). Validates issuer + lifetime (+ optional audience)
+/// and resolves signing keys from the configured JWKS URL.
+/// </summary>
+public sealed class ConfigureJwtBearer(IOptions<PostyFoxAuthOptions> auth, IJwksProvider jwks)
+    : IConfigureNamedOptions<JwtBearerOptions>
+{
+    public void Configure(string? name, JwtBearerOptions options)
+    {
+        if (name != AuthConstants.Jwt) return;
+        var o = auth.Value.Oidc;
+
+        options.RequireHttpsMetadata = false;
+        options.MapInboundClaims = true; // maps `sub` → ClaimTypes.NameIdentifier
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidIssuer = o.Issuer,
+            ValidateAudience = !string.IsNullOrEmpty(o.Audience),
+            ValidAudience = o.Audience,
+            ValidateLifetime = true,
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKeyResolver = (_, _, _, _) =>
+                string.IsNullOrEmpty(o.JwksUrl) ? [] : jwks.GetSigningKeys(o.JwksUrl)
+        };
+    }
+
+    public void Configure(JwtBearerOptions options) => Configure(Options.DefaultName, options);
+}

--- a/src/PostyFox.Web/Auth/PostyFoxAuthOptions.cs
+++ b/src/PostyFox.Web/Auth/PostyFoxAuthOptions.cs
@@ -4,11 +4,34 @@ public sealed class PostyFoxAuthOptions
 {
     public const string SectionName = "Auth";
 
-    /// <summary>When true, requests are authenticated as <see cref="DevUserId"/> without headers.</summary>
+    /// <summary>
+    /// Local/test-only identity: authenticates every request as <see cref="DevUserId"/> without any
+    /// credential. This is NOT a deployment parameter — no shipped configuration enables it; it is set
+    /// in-memory by the test host only. Real deployments authenticate via the OIDC bearer token
+    /// (<see cref="Oidc"/>) or an API key.
+    /// </summary>
     public bool DevMode { get; set; }
     public string DevUserId { get; set; } = "dev-user";
 
-    /// <summary>Identity header injected by oauth2-proxy after OIDC validation.</summary>
+    /// <summary>
+    /// Identity header injected by oauth2-proxy after OIDC validation. Only consulted in DevMode;
+    /// outside DevMode the APIs validate the OIDC bearer token themselves (see <see cref="Oidc"/>).
+    /// </summary>
     public string UserHeader { get; set; } = "X-Auth-Request-User";
     public string? EmailHeader { get; set; } = "X-Auth-Request-Email";
+
+    /// <summary>In-app OIDC bearer-token validation (defence-in-depth; not dependent on the edge).</summary>
+    public OidcOptions Oidc { get; set; } = new();
+
+    public sealed class OidcOptions
+    {
+        /// <summary>When true, an `Authorization: Bearer` token is validated against the OIDC keys.</summary>
+        public bool Enabled { get; set; }
+        /// <summary>Expected token issuer (the `iss` claim), e.g. the browser-facing Keycloak URL.</summary>
+        public string? Issuer { get; set; }
+        /// <summary>JWKS endpoint to fetch signing keys from (a back-channel-reachable URL).</summary>
+        public string? JwksUrl { get; set; }
+        /// <summary>Optional expected audience; when empty, audience is not validated.</summary>
+        public string? Audience { get; set; }
+    }
 }

--- a/src/PostyFox.Web/Extensions/WebExtensions.cs
+++ b/src/PostyFox.Web/Extensions/WebExtensions.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using PostyFox.Web.Auth;
 
 namespace PostyFox.Web.Extensions;
@@ -8,23 +10,39 @@ namespace PostyFox.Web.Extensions;
 public static class WebExtensions
 {
     /// <summary>
-    /// Registers dual authentication: oauth2-proxy header identity by default, or API key when
-    /// the X-API-Key header is present.
+    /// Registers authentication. Requests are routed by credential:
+    ///   - <c>X-API-Key</c> header       → hashed API-key scheme (external/machine callers)
+    ///   - <c>Authorization: Bearer</c>  → OIDC JWT validated in-app (JWKS) when OIDC is enabled
+    ///   - otherwise                     → DevMode-only local identity (no header trust in prod)
+    /// The OIDC edge (oauth2-proxy) should be the only public route and forward the bearer token.
     /// </summary>
     public static IServiceCollection AddPostyFoxAuth(this IServiceCollection services, IConfiguration config)
     {
         services.Configure<PostyFoxAuthOptions>(config.GetSection(PostyFoxAuthOptions.SectionName));
 
+        services.AddHttpClient("jwks");
+        services.AddSingleton<IJwksProvider, CachedJwksProvider>();
+        services.AddSingleton<IConfigureOptions<JwtBearerOptions>, ConfigureJwtBearer>();
+
         services.AddAuthentication(AuthConstants.PolicyScheme)
             .AddPolicyScheme(AuthConstants.PolicyScheme, "PostyFox", o =>
             {
                 o.ForwardDefaultSelector = ctx =>
-                    ctx.Request.Headers.ContainsKey(AuthConstants.ApiKeyHeader)
-                        ? AuthConstants.ApiKey
-                        : AuthConstants.Header;
+                {
+                    if (ctx.Request.Headers.ContainsKey(AuthConstants.ApiKeyHeader))
+                        return AuthConstants.ApiKey;
+
+                    var oidc = ctx.RequestServices.GetRequiredService<IOptions<PostyFoxAuthOptions>>().Value.Oidc;
+                    if (oidc.Enabled &&
+                        ctx.Request.Headers.Authorization.ToString().StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+                        return AuthConstants.Jwt;
+
+                    return AuthConstants.Header;
+                };
             })
             .AddScheme<AuthenticationSchemeOptions, HeaderAuthenticationHandler>(AuthConstants.Header, null)
-            .AddScheme<AuthenticationSchemeOptions, ApiKeyAuthenticationHandler>(AuthConstants.ApiKey, null);
+            .AddScheme<AuthenticationSchemeOptions, ApiKeyAuthenticationHandler>(AuthConstants.ApiKey, null)
+            .AddJwtBearer(AuthConstants.Jwt);
 
         services.AddAuthorization();
         return services;

--- a/src/PostyFox.Web/PostyFox.Web.csproj
+++ b/src/PostyFox.Web/PostyFox.Web.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />

--- a/src/PostyFox.Worker.Posting/appsettings.json
+++ b/src/PostyFox.Worker.Posting/appsettings.json
@@ -7,7 +7,7 @@
   "ConnectionStrings": {
     "Postgres": "Host=localhost;Port=5432;Database=postyfox;Username=postyfox;Password=postyfox"
   },
-  "Auth": { "DevMode": false, "UserHeader": "X-Auth-Request-User" },
+  "Auth": { "UserHeader": "X-Auth-Request-User" },
   "ObjectStore": { "ServiceUrl": "http://localhost:9000", "AccessKey": "minioadmin", "SecretKey": "minioadmin", "Bucket": "postyfox" },
   "RabbitMq": { "Host": "localhost", "Port": 5672, "User": "guest", "Password": "guest" },
   "Secrets": { "EncryptionKey": "" }

--- a/tests/PostyFox.Api.Core.Tests/JwtAuthTests.cs
+++ b/tests/PostyFox.Api.Core.Tests/JwtAuthTests.cs
@@ -1,0 +1,110 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using PostyFox.Api.Core.Tests.Support;
+using Xunit;
+
+namespace PostyFox.Api.Core.Tests;
+
+public class JwtAuthTests
+{
+    private const string Issuer = "http://kc.test/realms/PostyFox";
+    private const string Audience = "oauth2-proxy";
+    private const string Kid = "test-key-1";
+    private static readonly RSA SigningRsa = RSA.Create(2048);
+
+    private static string Jwks(RSA rsa)
+    {
+        var p = rsa.ExportParameters(false);
+        var n = Base64UrlEncoder.Encode(p.Modulus);
+        var e = Base64UrlEncoder.Encode(p.Exponent);
+        return $"{{\"keys\":[{{\"kty\":\"RSA\",\"use\":\"sig\",\"alg\":\"RS256\",\"kid\":\"{Kid}\",\"n\":\"{n}\",\"e\":\"{e}\"}}]}}";
+    }
+
+    private static string Token(RSA signer, string iss = Issuer, string aud = Audience, int expMinutes = 5)
+    {
+        var key = new RsaSecurityKey(signer) { KeyId = Kid };
+        return new JsonWebTokenHandler().CreateToken(new SecurityTokenDescriptor
+        {
+            Issuer = iss,
+            Audience = aud,
+            Expires = DateTime.UtcNow.AddMinutes(expMinutes),
+            Claims = new Dictionary<string, object> { ["sub"] = "user-123" },
+            SigningCredentials = new SigningCredentials(key, SecurityAlgorithms.RsaSha256)
+        });
+    }
+
+    private sealed class JwksStub(string json) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage r, CancellationToken ct)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(json) });
+    }
+
+    // JWKS advertises SigningRsa's public key; OIDC enabled; DevMode off.
+    private static WebApplicationFactory<Program> BuildFactory() =>
+        new CustomWebApplicationFactory { DevMode = false }.WithWebHostBuilder(b =>
+        {
+            b.ConfigureAppConfiguration((_, c) => c.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Auth:Oidc:Enabled"] = "true",
+                ["Auth:Oidc:Issuer"] = Issuer,
+                ["Auth:Oidc:Audience"] = Audience,
+                ["Auth:Oidc:JwksUrl"] = "http://jwks.test/certs"
+            }));
+            b.ConfigureTestServices(s =>
+                s.AddHttpClient("jwks").ConfigurePrimaryHttpMessageHandler(() => new JwksStub(Jwks(SigningRsa))));
+        });
+
+    private static async Task<HttpStatusCode> CallTemplates(WebApplicationFactory<Program> f, string? bearer)
+    {
+        var client = f.CreateClient();
+        if (bearer is not null) client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", bearer);
+        return (await client.GetAsync("/api/templates")).StatusCode;
+    }
+
+    [Fact]
+    public async Task Valid_bearer_token_is_accepted()
+    {
+        using var f = BuildFactory();
+        Assert.Equal(HttpStatusCode.OK, await CallTemplates(f, Token(SigningRsa)));
+    }
+
+    [Fact]
+    public async Task Token_signed_by_unknown_key_is_rejected()
+    {
+        using var f = BuildFactory();
+        using var attacker = RSA.Create(2048); // not in the JWKS
+        Assert.Equal(HttpStatusCode.Unauthorized, await CallTemplates(f, Token(attacker)));
+    }
+
+    [Fact]
+    public async Task Expired_token_is_rejected()
+    {
+        using var f = BuildFactory();
+        Assert.Equal(HttpStatusCode.Unauthorized, await CallTemplates(f, Token(SigningRsa, expMinutes: -5)));
+    }
+
+    [Fact]
+    public async Task Wrong_issuer_is_rejected()
+    {
+        using var f = BuildFactory();
+        Assert.Equal(HttpStatusCode.Unauthorized, await CallTemplates(f, Token(SigningRsa, iss: "http://evil/realms/PostyFox")));
+    }
+
+    [Fact]
+    public async Task No_credentials_is_unauthorized_and_header_is_not_trusted()
+    {
+        using var f = BuildFactory();
+        var client = f.CreateClient();
+        // A spoofed identity header must NOT authenticate outside DevMode.
+        client.DefaultRequestHeaders.Add("X-Auth-Request-User", "victim");
+        Assert.Equal(HttpStatusCode.Unauthorized, (await client.GetAsync("/api/templates")).StatusCode);
+    }
+}


### PR DESCRIPTION
- Reworked a failing healthcheck (curl was missing from base images)
- Enforced Keycloak and auth flows to be used even in dev scenarios, removing all the auth processes that allowed bypasses
- Fixed up the manual deploy workflow to allow it to actually ... deploy
- Fixed up the docker-compose stack for local dev to standup the correct stack, more aligned with deployed stack
- Correctly align the api's behind oauth-proxy for auth and control