### PR TITLE
Bug: Fixes Telegram integration

### DIFF
--- a/src/PostyFox.Api.Core/Endpoints/ServiceEndpoints.cs
+++ b/src/PostyFox.Api.Core/Endpoints/ServiceEndpoints.cs
@@ -78,8 +78,31 @@ public static class ServiceEndpoints
         connectors.MapGet("{id:guid}/targets", async (Guid id, ClaimsPrincipal user, ConnectorOperationsService svc, CancellationToken ct) =>
             await svc.ListTargetsAsync(user.UserId()!, id, ct) is { } targets ? Results.Ok(targets) : Results.NotFound())
         .WithSummary("List the delivery targets available on a connector")
+        .WithDescription("Fetched live from the platform (e.g. a Telegram account's chats). For connectors that support multiple targets, pick from this list which ones to expose via PUT .../destinations.")
         .Produces<IReadOnlyList<ConnectorTarget>>()
         .Produces(StatusCodes.Status404NotFound);
+
+        connectors.MapGet("{id:guid}/destinations", async (Guid id, ClaimsPrincipal user, ConnectorDestinationService svc, CancellationToken ct) =>
+            await svc.ListAsync(user.UserId()!, id, ct) is { } destinations ? Results.Ok(destinations) : Results.NotFound())
+        .WithSummary("List the destinations exposed for posting under a connector")
+        .WithDescription("For connectors that support multiple targets (e.g. Telegram), these are the chats/channels the compose form offers as individually selectable destinations.")
+        .Produces<IReadOnlyList<ConnectorDestinationDto>>()
+        .Produces(StatusCodes.Status404NotFound);
+
+        connectors.MapPut("{id:guid}/destinations", async (Guid id, SetConnectorDestinationsRequest body, ClaimsPrincipal user, ConnectorDestinationService svc, CancellationToken ct) =>
+            await svc.SetAsync(user.UserId()!, id, body.Destinations ?? [], ct) is { } destinations
+                ? Results.Ok(destinations)
+                : Results.BadRequest(new { error = "Unknown connector, or it does not support multiple targets" }))
+        .WithSummary("Replace the destinations exposed for posting under a connector")
+        .WithDescription("Pass the full desired set (matched by ExternalId) — entries not included are removed, new ones are added, and names are refreshed.")
+        .Produces<IReadOnlyList<ConnectorDestinationDto>>()
+        .ProducesProblem(StatusCodes.Status400BadRequest);
+
+        connectors.MapGet("destinations", async (ClaimsPrincipal user, ConnectorDestinationService svc, CancellationToken ct) =>
+            Results.Ok(await svc.ListAllAsync(user.UserId()!, ct)))
+        .WithSummary("List every destination the user has exposed across all their connectors")
+        .WithDescription("Flattened with each destination's owning connector, for the compose form to build its full set of selectable delivery targets.")
+        .Produces<IReadOnlyList<ConnectorDestinationSummaryDto>>();
 
         connectors.MapGet("{id:guid}/limits", async (Guid id, ClaimsPrincipal user, ConnectorOperationsService svc, CancellationToken ct) =>
             await svc.GetLimitsAsync(user.UserId()!, id, ct) is { } limits ? Results.Ok(limits) : Results.NotFound())

--- a/src/PostyFox.Application/Abstractions/IAppDbContext.cs
+++ b/src/PostyFox.Application/Abstractions/IAppDbContext.cs
@@ -14,6 +14,7 @@ public interface IAppDbContext
     DbSet<ServiceDefinition> ServiceDefinitions { get; }
     DbSet<UserConnector> UserConnectors { get; }
     DbSet<ConnectorCookiePairing> ConnectorCookiePairings { get; }
+    DbSet<ConnectorDestination> ConnectorDestinations { get; }
     DbSet<Template> Templates { get; }
     DbSet<ExternalTrigger> ExternalTriggers { get; }
     DbSet<ExternalInterest> ExternalInterests { get; }

--- a/src/PostyFox.Application/Connectors/ConnectorTypes.cs
+++ b/src/PostyFox.Application/Connectors/ConnectorTypes.cs
@@ -45,7 +45,15 @@ public sealed record ConnectorDescriptor(
     /// target; the values are stored on the <see cref="Domain.Entities.PostTarget"/> and applied over
     /// the connector's config at delivery. Null when the platform has no per-submission choices.
     /// </summary>
-    string? PostOptionsSchema = null)
+    string? PostOptionsSchema = null,
+    /// <summary>
+    /// True when a single connector login can fan out to several independently selectable delivery
+    /// destinations (e.g. one Telegram MTProto login reaching many chats/channels) — see
+    /// <see cref="Domain.Entities.ConnectorDestination"/>. The compose UI then lets the author pick
+    /// individual exposed destinations rather than the connector itself. False (the default) keeps
+    /// the legacy 1:1 connector-to-destination behaviour every other platform uses.
+    /// </summary>
+    bool SupportsMultipleTargets = false)
 {
     /// <summary>True when authentication is handed off from PostyFox Connect browser clients.</summary>
     public bool SupportsCookiePairing => CookiePairing is not null;

--- a/src/PostyFox.Application/Dtos/Dtos.cs
+++ b/src/PostyFox.Application/Dtos/Dtos.cs
@@ -29,9 +29,45 @@ public sealed record ServiceDefinitionDto(
     /// <see cref="ConfigSchema"/>; null when the platform has none. Rendered by the compose form once
     /// per selected target, and submitted as <see cref="CreatePostRequest.TargetOptions"/>.
     /// </summary>
-    string? PostOptionsSchema);
+    string? PostOptionsSchema,
+    /// <summary>
+    /// True when one connector login can fan out to several independently selectable delivery
+    /// destinations (see <see cref="Connectors.ConnectorDescriptor.SupportsMultipleTargets"/>). The
+    /// compose UI lists each of the connector's exposed <c>ConnectorDestination</c>s as its own
+    /// selectable target instead of the connector itself.
+    /// </summary>
+    bool SupportsMultipleTargets = false);
 
 public sealed record UserConnectorDto(Guid Id, string ServiceDefinitionId, string Platform, string DisplayName, string ConfigJson, bool Enabled);
+
+/// <summary>
+/// A destination the user has chosen to expose for posting under one connector login (e.g. one
+/// Telegram chat/channel reachable from a single MTProto login). See
+/// <see cref="Domain.Entities.ConnectorDestination"/>.
+/// </summary>
+public sealed record ConnectorDestinationDto(Guid Id, Guid ConnectorId, string ExternalId, string Name);
+
+/// <summary>
+/// A <see cref="ConnectorDestinationDto"/> flattened with its owning connector's identity, for the
+/// "every destination across every connector" listing the compose form uses to build its full set
+/// of selectable delivery targets.
+/// </summary>
+public sealed record ConnectorDestinationSummaryDto(
+    Guid Id,
+    Guid ConnectorId,
+    string Platform,
+    string ConnectorDisplayName,
+    string ExternalId,
+    string Name);
+
+/// <summary>One destination to expose, as chosen from a connector's live <c>ListTargetsAsync</c> results.</summary>
+public sealed record ConnectorDestinationInput(string ExternalId, string Name);
+
+/// <summary>
+/// Replaces the full set of destinations exposed for a connector (add/update/remove in one call) —
+/// simpler for the client than issuing individual add/remove requests as checkboxes are toggled.
+/// </summary>
+public sealed record SetConnectorDestinationsRequest(IReadOnlyList<ConnectorDestinationInput> Destinations);
 
 /// <summary>
 /// A site the signed-in user can hand a browser session to. One entry per cookie-pairing platform:
@@ -60,6 +96,13 @@ public sealed record TemplateDto(Guid Id, string Title, string MarkdownBody);
 public sealed record TemplateUpsertRequest(Guid? Id, string Title, string MarkdownBody);
 
 public sealed record CreatePostRequest(
+    /// <summary>
+    /// Ids of the destinations to deliver to. Each entry is either a <see cref="Domain.Entities.UserConnector"/> id
+    /// (the legacy 1:1 behaviour — the connector's own configured destination is used), or a
+    /// <see cref="ConnectorDestinationDto"/> id for a connector that declares
+    /// <see cref="Connectors.ConnectorDescriptor.SupportsMultipleTargets"/> (Telegram) — in which case
+    /// delivery goes to that specific exposed chat/channel rather than the connector's default.
+    /// </summary>
     IReadOnlyList<Guid> Targets,
     string? Title,
     string? Description,
@@ -71,8 +114,8 @@ public sealed record CreatePostRequest(
     DateTimeOffset? PostAt,
     ContentRating? Rating = null,
     /// <summary>
-    /// Per-submission platform choices, keyed by target connector id — FurAffinity's category,
-    /// species, gender and folders. Validated against that platform's
+    /// Per-submission platform choices, keyed by the same id used in <see cref="Targets"/>  —
+    /// FurAffinity's category, species, gender and folders. Validated against that platform's
     /// <see cref="ServiceDefinitionDto.PostOptionsSchema"/>; anything it does not declare is dropped.
     /// Entries for connectors outside <see cref="Targets"/> are ignored.
     /// </summary>

--- a/src/PostyFox.Application/Posting/DeliverTargetHandler.cs
+++ b/src/PostyFox.Application/Posting/DeliverTargetHandler.cs
@@ -72,7 +72,7 @@ public sealed class DeliverTargetHandler(
             userId,
             EffectiveConfig(connector.Describe().PostOptionsSchema, configJson, target.OptionsJson),
             secretJson,
-            null);
+            target.TargetId);
 
         target.Status = TargetStatus.Delivering;
         target.Attempts++;

--- a/src/PostyFox.Application/Posting/PostIntakeService.cs
+++ b/src/PostyFox.Application/Posting/PostIntakeService.cs
@@ -23,7 +23,16 @@ public sealed class PostIntakeService(
     private readonly PipelineOptions _options = options.Value;
 
     /// <summary>
-    /// Persists a post + one target per selected connector, stores the payload, and enqueues
+    /// One resolved delivery destination for a post: either a whole connector (the legacy 1:1
+    /// behaviour) or one of its exposed <see cref="ConnectorDestination"/>s. <see cref="SelectionId"/>
+    /// is whichever id the client sent in <see cref="CreatePostRequest.Targets"/>, used to look up
+    /// per-submission <see cref="CreatePostRequest.TargetOptions"/>.
+    /// </summary>
+    private sealed record ResolvedDestination(
+        Guid SelectionId, Guid ConnectorId, string DisplayName, string Platform, string? TargetId, string? TargetName);
+
+    /// <summary>
+    /// Persists a post + one target per selected destination, stores the payload, and enqueues
     /// generation for each target (delayed if scheduled). Returns null if no valid targets.
     /// </summary>
     /// <exception cref="ConnectorValidationException">
@@ -34,11 +43,27 @@ public sealed class PostIntakeService(
         var targetIds = (request.Targets ?? []).Distinct().ToList();
         if (targetIds.Count == 0) return null;
 
+        // A requested id is either a whole connector (single-destination platforms, and the legacy
+        // behaviour every platform used before per-destination selection existed) or one of that
+        // connector's exposed ConnectorDestinations (multi-target platforms like Telegram — see
+        // ConnectorDescriptor.SupportsMultipleTargets). Both id spaces are plain Guids from different
+        // tables, so a requested id can only ever match one of them.
         var connectors = await db.UserConnectors
             .Include(c => c.ServiceDefinition)
             .Where(c => c.UserId == userId && c.Enabled && targetIds.Contains(c.Id))
             .ToListAsync(ct);
-        if (connectors.Count == 0) return null;
+
+        var destinations = await db.ConnectorDestinations
+            .Include(d => d.Connector!.ServiceDefinition)
+            .Where(d => d.Connector!.UserId == userId && d.Connector!.Enabled && targetIds.Contains(d.Id))
+            .ToListAsync(ct);
+
+        var resolved = new List<ResolvedDestination>();
+        resolved.AddRange(connectors.Select(c =>
+            new ResolvedDestination(c.Id, c.Id, c.DisplayName, c.ServiceDefinition!.Platform, null, null)));
+        resolved.AddRange(destinations.Select(d =>
+            new ResolvedDestination(d.Id, d.ConnectorId, d.Connector!.DisplayName, d.Connector!.ServiceDefinition!.Platform, d.ExternalId, d.Name)));
+        if (resolved.Count == 0) return null;
 
         var now = clock.UtcNow;
         var post = new Post
@@ -59,17 +84,18 @@ public sealed class PostIntakeService(
             UpdatedAt = now
         };
 
-        foreach (var connector in connectors)
+        foreach (var destination in resolved)
         {
-            var platform = connector.ServiceDefinition!.Platform;
             post.Targets.Add(new PostTarget
             {
                 Id = Guid.NewGuid(),
                 PostId = post.Id,
-                ConnectorId = connector.Id,
-                Platform = platform,
-                OptionsJson = TargetOptionsFor(platform, connector.DisplayName,
-                    request.TargetOptions?.GetValueOrDefault(connector.Id)),
+                ConnectorId = destination.ConnectorId,
+                Platform = destination.Platform,
+                TargetId = destination.TargetId,
+                TargetName = destination.TargetName,
+                OptionsJson = TargetOptionsFor(destination.Platform, destination.DisplayName,
+                    request.TargetOptions?.GetValueOrDefault(destination.SelectionId)),
                 Status = TargetStatus.Queued,
                 CreatedAt = now,
                 UpdatedAt = now

--- a/src/PostyFox.Application/Posting/PostStatusService.cs
+++ b/src/PostyFox.Application/Posting/PostStatusService.cs
@@ -4,6 +4,7 @@ using PostyFox.Application.Abstractions;
 using PostyFox.Application.Connectors;
 using PostyFox.Application.Dtos;
 using PostyFox.Application.Options;
+using PostyFox.Domain.Entities;
 using PostyFox.Domain.Enums;
 
 namespace PostyFox.Application.Posting;
@@ -44,6 +45,28 @@ public sealed class PostStatusService(IAppDbContext db, IClock clock, IOptions<R
             .FirstOrDefaultAsync(p => p.Id == postId && p.UserId == userId, ct);
         if (post is null) return null;
 
+        // "Post again" must re-tick the exact same destination the post was originally sent to, not
+        // just its connector — for a multi-target platform (Telegram) that means resolving each
+        // target's chat id back to the ConnectorDestination the compose form originally selected.
+        // Falls back to the connector itself if that destination is no longer exposed.
+        var connectorIdsWithTarget = post.Targets
+            .Where(t => t.ConnectorId.HasValue && t.TargetId != null)
+            .Select(t => t.ConnectorId!.Value)
+            .Distinct()
+            .ToList();
+        var destinationLookup = connectorIdsWithTarget.Count == 0
+            ? new Dictionary<(Guid ConnectorId, string ExternalId), Guid>()
+            : (await db.ConnectorDestinations
+                .Where(d => connectorIdsWithTarget.Contains(d.ConnectorId))
+                .Select(d => new { d.Id, d.ConnectorId, d.ExternalId })
+                .ToListAsync(ct))
+                .ToDictionary(d => (d.ConnectorId, d.ExternalId), d => d.Id);
+
+        Guid SelectionId(PostTarget t) =>
+            t.TargetId != null && destinationLookup.TryGetValue((t.ConnectorId!.Value, t.TargetId), out var destinationId)
+                ? destinationId
+                : t.ConnectorId!.Value;
+
         return new PostContentDto(
             string.IsNullOrEmpty(post.Title) ? null : post.Title,
             string.IsNullOrEmpty(post.Description) ? null : post.Description,
@@ -52,15 +75,15 @@ public sealed class PostStatusService(IAppDbContext db, IClock clock, IOptions<R
             Json.Deserialize<List<MediaRef>>(post.MediaManifestJson) ?? [],
             post.TemplateId,
             Json.Deserialize<Dictionary<string, string>>(post.VariablesJson) ?? new(),
-            post.Targets.Where(t => t.ConnectorId.HasValue).Select(t => t.ConnectorId!.Value).Distinct().ToList(),
+            post.Targets.Where(t => t.ConnectorId.HasValue).Select(SelectionId).Distinct().ToList(),
             post.PostAt,
             post.Rating,
             post.Targets
                 .Where(t => t.ConnectorId.HasValue)
-                .Select(t => (t.ConnectorId!.Value,
+                .Select(t => (SelectionId: SelectionId(t),
                     Options: Json.Deserialize<Dictionary<string, string>>(t.OptionsJson)))
                 .Where(x => x.Options is { Count: > 0 })
-                .GroupBy(x => x.Item1)
+                .GroupBy(x => x.SelectionId)
                 .ToDictionary(
                     g => g.Key,
                     g => (IReadOnlyDictionary<string, string>)g.First().Options!));

--- a/src/PostyFox.Application/ServiceCollectionExtensions.cs
+++ b/src/PostyFox.Application/ServiceCollectionExtensions.cs
@@ -24,6 +24,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<TemplateService>();
         services.AddScoped<UserConnectorService>();
         services.AddScoped<ConnectorOperationsService>();
+        services.AddScoped<ConnectorDestinationService>();
         services.AddScoped<ConnectorCookiePairingService>();
         services.AddScoped<OperationalSecretService>();
         services.AddScoped<PostIntakeService>();

--- a/src/PostyFox.Application/Services/ConnectorDestinationService.cs
+++ b/src/PostyFox.Application/Services/ConnectorDestinationService.cs
@@ -1,0 +1,105 @@
+using Microsoft.EntityFrameworkCore;
+using PostyFox.Application.Abstractions;
+using PostyFox.Application.Connectors;
+using PostyFox.Application.Dtos;
+using PostyFox.Domain.Entities;
+
+namespace PostyFox.Application.Services;
+
+/// <summary>
+/// Manages the destinations a user exposes for posting under one connector login (see
+/// <see cref="ConnectorDestination"/>) — e.g. picking which Telegram chats reachable from a single
+/// MTProto login should show up as individually selectable targets in the compose form. Only
+/// meaningful for connectors that declare
+/// <see cref="ConnectorDescriptor.SupportsMultipleTargets"/>; live discovery of what can
+/// be exposed (e.g. Telegram's chat list) is a separate concern handled by
+/// <see cref="ConnectorOperationsService.ListTargetsAsync"/>.
+/// </summary>
+public sealed class ConnectorDestinationService(IAppDbContext db, IClock clock, IConnectorRegistry registry)
+{
+    /// <summary>Exposed destinations for one connector, or null if it isn't the user's.</summary>
+    public async Task<IReadOnlyList<ConnectorDestinationDto>?> ListAsync(string userId, Guid connectorId, CancellationToken ct = default)
+    {
+        var owned = await db.UserConnectors.AnyAsync(c => c.UserId == userId && c.Id == connectorId, ct);
+        if (!owned) return null;
+
+        return await db.ConnectorDestinations
+            .Where(d => d.ConnectorId == connectorId)
+            .OrderBy(d => d.Name)
+            .Select(d => new ConnectorDestinationDto(d.Id, d.ConnectorId, d.ExternalId, d.Name))
+            .ToListAsync(ct);
+    }
+
+    /// <summary>
+    /// Every destination the user has exposed across all their connectors, flattened with the owning
+    /// connector's identity — what the compose form needs to build its full set of selectable targets
+    /// (single-destination connectors plus each exposed destination of multi-target ones).
+    /// </summary>
+    public async Task<IReadOnlyList<ConnectorDestinationSummaryDto>> ListAllAsync(string userId, CancellationToken ct = default) =>
+        await db.ConnectorDestinations
+            .Include(d => d.Connector!.ServiceDefinition)
+            .Where(d => d.Connector!.UserId == userId)
+            .OrderBy(d => d.Connector!.DisplayName).ThenBy(d => d.Name)
+            .Select(d => new ConnectorDestinationSummaryDto(
+                d.Id, d.ConnectorId, d.Connector!.ServiceDefinition!.Platform, d.Connector!.DisplayName, d.ExternalId, d.Name))
+            .ToListAsync(ct);
+
+    /// <summary>
+    /// Replaces the full set of destinations exposed for a connector with <paramref name="selections"/>
+    /// (matched by <see cref="ConnectorDestinationInput.ExternalId"/>): existing rows not present are
+    /// removed, new ones are added, and names are refreshed in case the platform-side label changed
+    /// since it was last exposed. Returns null if the connector isn't the user's or doesn't support
+    /// multiple targets.
+    /// </summary>
+    public async Task<IReadOnlyList<ConnectorDestinationDto>?> SetAsync(
+        string userId, Guid connectorId, IReadOnlyList<ConnectorDestinationInput> selections, CancellationToken ct = default)
+    {
+        var uc = await db.UserConnectors.Include(c => c.ServiceDefinition)
+            .FirstOrDefaultAsync(c => c.UserId == userId && c.Id == connectorId, ct);
+        if (uc?.ServiceDefinition is null) return null;
+        if (!registry.TryGet(uc.ServiceDefinition.Platform, out var connector) || !connector.Describe().SupportsMultipleTargets)
+            return null;
+
+        var existing = await db.ConnectorDestinations.Where(d => d.ConnectorId == connectorId).ToListAsync(ct);
+        var wanted = selections.Where(s => !string.IsNullOrWhiteSpace(s.ExternalId))
+            .GroupBy(s => s.ExternalId, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.Last().Name, StringComparer.Ordinal);
+
+        var now = clock.UtcNow;
+        foreach (var stale in existing.Where(d => !wanted.ContainsKey(d.ExternalId)))
+            db.ConnectorDestinations.Remove(stale);
+
+        foreach (var row in existing.Where(d => wanted.ContainsKey(d.ExternalId)))
+        {
+            var name = wanted[row.ExternalId];
+            if (row.Name != name)
+            {
+                row.Name = name;
+                row.UpdatedAt = now;
+            }
+        }
+
+        var existingIds = existing.Select(d => d.ExternalId).ToHashSet(StringComparer.Ordinal);
+        foreach (var (externalId, name) in wanted)
+        {
+            if (existingIds.Contains(externalId)) continue;
+            db.ConnectorDestinations.Add(new ConnectorDestination
+            {
+                Id = Guid.NewGuid(),
+                ConnectorId = connectorId,
+                ExternalId = externalId,
+                Name = name,
+                CreatedAt = now,
+                UpdatedAt = now
+            });
+        }
+
+        await db.SaveChangesAsync(ct);
+
+        return await db.ConnectorDestinations
+            .Where(d => d.ConnectorId == connectorId)
+            .OrderBy(d => d.Name)
+            .Select(d => new ConnectorDestinationDto(d.Id, d.ConnectorId, d.ExternalId, d.Name))
+            .ToListAsync(ct);
+    }
+}

--- a/src/PostyFox.Application/Services/ServiceCatalogService.cs
+++ b/src/PostyFox.Application/Services/ServiceCatalogService.cs
@@ -27,7 +27,7 @@ public sealed class ServiceCatalogService(IAppDbContext db, IConnectorRegistry c
     private ServiceDefinitionDto Map(ServiceDefinition s)
     {
         bool supportsTitle = false, supportsMedia = false, supportsThreads = false, supportsOAuth = false,
-            supportsCookiePairing = false, supportsRating = false, requiresRating = false;
+            supportsCookiePairing = false, supportsRating = false, requiresRating = false, supportsMultipleTargets = false;
         int? maxContentLength = null;
         string? postOptionsSchema = null;
         if (connectors.TryGet(s.Platform, out var connector))
@@ -42,11 +42,12 @@ public sealed class ServiceCatalogService(IAppDbContext db, IConnectorRegistry c
             supportsRating = d.SupportsRating;
             requiresRating = d.RequiresRating;
             postOptionsSchema = d.PostOptionsSchema;
+            supportsMultipleTargets = d.SupportsMultipleTargets;
         }
 
         return new ServiceDefinitionDto(
             s.Id, s.Name, s.Enabled, s.ConfigSchema, s.SecureConfigSchema, s.Platform,
             supportsTitle, supportsMedia, supportsThreads, maxContentLength, supportsOAuth,
-            supportsCookiePairing, supportsRating, requiresRating, postOptionsSchema);
+            supportsCookiePairing, supportsRating, requiresRating, postOptionsSchema, supportsMultipleTargets);
     }
 }

--- a/src/PostyFox.Domain/Entities/ConnectorDestination.cs
+++ b/src/PostyFox.Domain/Entities/ConnectorDestination.cs
@@ -1,0 +1,22 @@
+namespace PostyFox.Domain.Entities;
+
+/// <summary>
+/// A specific destination within a connected account that the user has chosen to expose for
+/// posting — e.g. one Telegram chat/channel reachable from a single MTProto login. Lets a
+/// connector that authenticates once (<see cref="UserConnector"/>) fan out to several delivery
+/// destinations without the user creating a duplicate connector/login per destination.
+/// <see cref="ExternalId"/> is the platform's own identifier for the destination (a Telegram chat
+/// id); <see cref="Name"/> is a human-readable label captured at the time it was exposed (kept in
+/// sync when the user re-selects, so a renamed channel doesn't show a stale name).
+/// </summary>
+public class ConnectorDestination
+{
+    public Guid Id { get; set; }
+    public Guid ConnectorId { get; set; }
+    public string ExternalId { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset UpdatedAt { get; set; }
+
+    public UserConnector? Connector { get; set; }
+}

--- a/src/PostyFox.Domain/Entities/PostTarget.cs
+++ b/src/PostyFox.Domain/Entities/PostTarget.cs
@@ -10,6 +10,15 @@ public class PostTarget
     public Guid? ConnectorId { get; set; }
     public string Platform { get; set; } = string.Empty;
     /// <summary>
+    /// The specific destination within the connector's account to deliver to (e.g. a Telegram chat
+    /// id), when the target was selected via a <see cref="ConnectorDestination"/> rather than the
+    /// connector's single default destination. Null means "use the connector's own config" (the
+    /// legacy 1:1 connector-to-destination behaviour every other platform still uses).
+    /// </summary>
+    public string? TargetId { get; set; }
+    /// <summary>Human-readable label for <see cref="TargetId"/>, captured at selection time for display.</summary>
+    public string? TargetName { get; set; }
+    /// <summary>
     /// The author's per-submission choices for this platform (FurAffinity's category, species, gender,
     /// gallery folders), as declared by its connector descriptor's <c>PostOptionsSchema</c>. Applied
     /// over the connector's own config at delivery; <c>{}</c> means "use the platform's defaults".

--- a/src/PostyFox.Infrastructure/Connectors/BlobSessionStore.cs
+++ b/src/PostyFox.Infrastructure/Connectors/BlobSessionStore.cs
@@ -1,44 +1,97 @@
+using Microsoft.Extensions.Logging;
 using PostyFox.Application.Abstractions;
 
 namespace PostyFox.Infrastructure.Connectors;
 
 /// <summary>
 /// MTProto session stream persisted to the object store (port of the legacy blob-backed
-/// TelegramStore). Loads existing session on open; flushes changes back to object storage.
+/// TelegramStore). Loads existing session on open; persists changes back to object storage.
+///
+/// IMPORTANT: WTelegramClient's <c>Session.Save()</c> persists session state via
+/// <c>Position = 0; Write(...); SetLength(...)</c> — it never calls <see cref="Stream.Flush"/>,
+/// and <c>Client.Dispose()</c> only disposes the underlying stream (which does not call Flush
+/// either). So persistence MUST be triggered from <see cref="Write(byte[], int, int)"/> /
+/// <see cref="Write(ReadOnlySpan{byte})"/> (or <see cref="SetLength"/>) rather than from
+/// <see cref="Flush"/>, or session state is silently held only in memory and lost when the
+/// client is disposed.
 /// </summary>
 public sealed class BlobSessionStore : MemoryStream
 {
     private readonly IObjectStore _store;
     private readonly string _container;
     private readonly string _key;
+    private readonly ILogger? _logger;
 
-    private BlobSessionStore(IObjectStore store, string container, string key) : base()
+    private BlobSessionStore(IObjectStore store, string container, string key, ILogger? logger) : base()
     {
         _store = store;
         _container = container;
         _key = key;
+        _logger = logger;
     }
 
-    public static async Task<BlobSessionStore> OpenAsync(IObjectStore store, string userId, CancellationToken ct = default)
+    public static async Task<BlobSessionStore> OpenAsync(IObjectStore store, string userId, CancellationToken ct = default, ILogger? logger = null)
     {
-        var s = new BlobSessionStore(store, "telegram", userId);
+        var s = new BlobSessionStore(store, "telegram", userId, logger);
         if (await store.ExistsAsync("telegram", userId, ct))
         {
             await using var existing = await store.GetAsync("telegram", userId, ct);
             await existing.CopyToAsync(s, ct);
             s.Position = 0;
+            logger?.LogDebug("Telegram session state loaded from object store for {User} ({Bytes} bytes)", userId, s.Length);
+        }
+        else
+        {
+            logger?.LogDebug("No existing Telegram session state found in object store for {User}; starting fresh", userId);
         }
         return s;
     }
 
-    public override void Flush()
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        base.Write(buffer, offset, count);
+        Persist();
+    }
+
+    public override void Write(ReadOnlySpan<byte> buffer)
+    {
+        base.Write(buffer);
+        Persist();
+    }
+
+    public override void SetLength(long value)
+    {
+        base.SetLength(value);
+        Persist();
+    }
+
+    private void Persist()
     {
         if (Length == 0) return;
         var current = Position;
         Position = 0;
-        // Persist synchronously — WTelegramClient calls Flush on its own cadence.
-        _store.PutAsync(_container, _key, new MemoryStream(ToArray()), "application/octet-stream")
-            .GetAwaiter().GetResult();
-        Position = current;
+        try
+        {
+            // Persist synchronously — Session.Save() writes/truncates the stream directly and never
+            // calls Flush(), so this is the only reliable hook for pushing state to the object store.
+            _store.PutAsync(_container, _key, new MemoryStream(ToArray()), "application/octet-stream")
+                .GetAwaiter().GetResult();
+            _logger?.LogDebug("Persisted Telegram session state to object store {Container}/{Key} ({Bytes} bytes)", _container, _key, Length);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Failed to persist Telegram session state to object store {Container}/{Key}", _container, _key);
+            throw;
+        }
+        finally
+        {
+            Position = current;
+        }
+    }
+
+    public override void Flush()
+    {
+        // No-op: WTelegramClient never calls Flush() on the session stream (see class remarks).
+        // Persistence happens eagerly in Write/SetLength instead.
     }
 }

--- a/src/PostyFox.Infrastructure/Connectors/TelegramConnector.cs
+++ b/src/PostyFox.Infrastructure/Connectors/TelegramConnector.cs
@@ -8,6 +8,14 @@ namespace PostyFox.Infrastructure.Connectors;
 /// Config: { "PhoneNumber": "..", "DefaultPostingTarget": "&lt;chatId&gt;" }. The session is
 /// persisted per user in the object store; api id/hash come from the secret store. All MTProto
 /// work is delegated to <see cref="ITelegramGateway"/>.
+///
+/// TARGETS: one Telegram login (phone number) can reach many chats/channels, so this connector
+/// declares <see cref="ConnectorDescriptor.SupportsMultipleTargets"/>. Users expose the specific
+/// chats they want selectable at compose time as <see cref="Domain.Entities.ConnectorDestination"/>
+/// rows (populated from <see cref="ListTargetsAsync"/>); <see cref="ConnectorContext.TargetId"/>
+/// then carries the chosen chat id per post-target, taking priority over the connector's
+/// <c>DefaultPostingTarget</c> fallback (kept for backward compatibility with connectors configured
+/// before per-post destination selection existed).
 /// </summary>
 public sealed class TelegramConnector(ITelegramGateway gateway) : IConnector
 {
@@ -15,7 +23,7 @@ public sealed class TelegramConnector(ITelegramGateway gateway) : IConnector
 
     public ConnectorDescriptor Describe() =>
         new(PlatformKey, "Telegram", SupportsTitle: true, SupportsMedia: true, SupportsThreads: false, 4096,
-            MediaSpec: PlatformMediaSpecs.Telegram);
+            MediaSpec: PlatformMediaSpecs.Telegram, SupportsMultipleTargets: true);
 
     public async Task<AuthState> IsAuthenticatedAsync(ConnectorContext context, CancellationToken ct = default)
     {
@@ -34,7 +42,9 @@ public sealed class TelegramConnector(ITelegramGateway gateway) : IConnector
     public async Task<DeliveryResult> DeliverAsync(ConnectorContext context, RenderedPost post, CancellationToken ct = default)
     {
         var phone = ConnectorJson.Field(context.ConfigJson, "PhoneNumber");
-        var chatId = ConnectorJson.Field(context.ConfigJson, "DefaultPostingTarget") ?? context.TargetId;
+        // An explicitly selected destination (one of the connector's exposed ConnectorDestinations)
+        // always wins over the connector-wide default, so the same login can fan out to several chats.
+        var chatId = context.TargetId ?? ConnectorJson.Field(context.ConfigJson, "DefaultPostingTarget");
         if (string.IsNullOrWhiteSpace(phone)) return DeliveryResult.Fail("No phone number configured");
         if (string.IsNullOrWhiteSpace(chatId)) return DeliveryResult.Fail("No target chat configured");
 

--- a/src/PostyFox.Infrastructure/Connectors/TelegramConnector.cs
+++ b/src/PostyFox.Infrastructure/Connectors/TelegramConnector.cs
@@ -14,7 +14,7 @@ public sealed class TelegramConnector(ITelegramGateway gateway) : IConnector
     public const string PlatformKey = "Telegram";
 
     public ConnectorDescriptor Describe() =>
-        new(PlatformKey, "Telegram", SupportsTitle: true, SupportsMedia: false, SupportsThreads: false, 4096,
+        new(PlatformKey, "Telegram", SupportsTitle: true, SupportsMedia: true, SupportsThreads: false, 4096,
             MediaSpec: PlatformMediaSpecs.Telegram);
 
     public async Task<AuthState> IsAuthenticatedAsync(ConnectorContext context, CancellationToken ct = default)

--- a/src/PostyFox.Infrastructure/Connectors/WTelegramGateway.cs
+++ b/src/PostyFox.Infrastructure/Connectors/WTelegramGateway.cs
@@ -107,7 +107,16 @@ public sealed class WTelegramGateway(
             {
                 using var ms = new MemoryStream(content[0].Data);
                 var file = await client.UploadFileAsync(ms, content[0].FileName);
-                var msg = await client.SendMediaAsync(peer, text, file, content[0].ContentType, entities: entities);
+                // Client.SendMediaAsync only auto-detects photo-vs-document from the filename
+                // extension when its mimeType parameter is null; passing our resolved content type
+                // (as we did before) skips that check entirely and always sends an
+                // InputMediaUploadedDocument — i.e. every image arrived in Telegram as a "file"
+                // instead of a photo. Build the InputMedia ourselves instead, exactly as the album
+                // path below already (correctly) does.
+                InputMedia inputMedia = content[0].ContentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase)
+                    ? new InputMediaUploadedPhoto { file = file }
+                    : new InputMediaUploadedDocument { file = file, mime_type = content[0].ContentType };
+                var msg = await client.SendMessageAsync(peer, text, inputMedia, entities: entities);
                 return DeliveryResult.Ok(msg.id.ToString());
             }
 

--- a/src/PostyFox.Infrastructure/Connectors/WTelegramGateway.cs
+++ b/src/PostyFox.Infrastructure/Connectors/WTelegramGateway.cs
@@ -12,11 +12,6 @@ namespace PostyFox.Infrastructure.Connectors;
 /// <summary>
 /// MTProto gateway backed by WTelegramClient. Sessions are persisted per user in the object
 /// store; interactive login clients are held in-process for the duration of the login flow.
-///
-/// STATEFULNESS: the login-flow client cache is per-instance. Route all Telegram operations for a
-/// given user to a single instance (e.g. a dedicated telegram-worker with consistent hashing on
-/// userId) so concurrent replicas do not corrupt an in-progress session — see the reimplementation
-/// plan §4.5.
 /// </summary>
 public sealed class WTelegramGateway(
     IObjectStore objectStore,
@@ -40,7 +35,8 @@ public sealed class WTelegramGateway(
     private async Task<WTelegram.Client> CreateClientAsync(string userId, string phone, CancellationToken ct)
     {
         var (apiId, apiHash) = await ApiAsync(ct);
-        var store = await BlobSessionStore.OpenAsync(objectStore, userId, ct);
+        logger.LogDebug("Opening Telegram session store ({Store}) for {User}", objectStore.GetType().Name, userId);
+        var store = await BlobSessionStore.OpenAsync(objectStore, userId, ct, logger);
         return new WTelegram.Client(what => what switch
         {
             "api_id" => apiId.ToString(),
@@ -56,7 +52,9 @@ public sealed class WTelegramGateway(
         {
             using var client = await CreateClientAsync(userId, phoneNumber, ct);
             await client.LoginUserIfNeeded();
-            return client.UserId != 0;
+            var authenticated = client.UserId != 0;
+            logger.LogDebug("Telegram session for {User} authenticated={Authenticated} (UserId={TelegramUserId})", userId, authenticated, client.UserId);
+            return authenticated;
         }
         catch (Exception ex)
         {
@@ -103,6 +101,7 @@ public sealed class WTelegramGateway(
             }
 
             var content = await mediaResolver.ResolveAsync(media, mediaSpec, ct);
+            logger.LogDebug("Telegram delivery for {User}: resolved {Count} media item(s) for chat {Chat}", userId, content.Count, chatId);
 
             if (content.Count == 1)
             {
@@ -136,6 +135,7 @@ public sealed class WTelegramGateway(
     {
         var client = _loginClients.GetOrAdd(userId, _ => CreateClientAsync(userId, phoneNumber, ct).GetAwaiter().GetResult());
         var next = await client.Login(value ?? phoneNumber);
+        logger.LogDebug("Telegram login step for {User} returned '{Step}'", userId, next ?? "null");
         switch (next)
         {
             case "verification_code":
@@ -143,7 +143,11 @@ public sealed class WTelegramGateway(
             case "password":
                 return new TelegramLoginStep(TelegramLoginStep.NeedsPassword, "value", "2FA Password");
             default:
-                if (_loginClients.TryRemove(userId, out var done)) done.Dispose(); // Dispose flushes the session to the object store
+                // Session state is persisted eagerly by BlobSessionStore on every write (see its
+                // remarks) — Dispose here only tears down the client/network resources, it does not
+                // itself trigger persistence.
+                if (_loginClients.TryRemove(userId, out var done)) done.Dispose();
+                logger.LogInformation("Telegram login completed for {User}", userId);
                 return new TelegramLoginStep(TelegramLoginStep.Complete);
         }
     }

--- a/src/PostyFox.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/PostyFox.Infrastructure/Persistence/AppDbContext.cs
@@ -11,6 +11,7 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
     public DbSet<ServiceDefinition> ServiceDefinitions => Set<ServiceDefinition>();
     public DbSet<UserConnector> UserConnectors => Set<UserConnector>();
     public DbSet<ConnectorCookiePairing> ConnectorCookiePairings => Set<ConnectorCookiePairing>();
+    public DbSet<ConnectorDestination> ConnectorDestinations => Set<ConnectorDestination>();
     public DbSet<Template> Templates => Set<Template>();
     public DbSet<ExternalTrigger> ExternalTriggers => Set<ExternalTrigger>();
     public DbSet<ExternalInterest> ExternalInterests => Set<ExternalInterest>();
@@ -56,6 +57,18 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
             e.Property(x => x.TokenHash).HasMaxLength(64);
             e.HasIndex(x => x.ConnectorId).IsUnique();
             e.HasIndex(x => x.ExpiresAt);
+            e.HasOne(x => x.Connector)
+                .WithMany()
+                .HasForeignKey(x => x.ConnectorId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        b.Entity<ConnectorDestination>(e =>
+        {
+            e.ToTable("connector_destinations");
+            e.HasKey(x => x.Id);
+            e.HasIndex(x => x.ConnectorId);
+            e.HasIndex(x => new { x.ConnectorId, x.ExternalId }).IsUnique();
             e.HasOne(x => x.Connector)
                 .WithMany()
                 .HasForeignKey(x => x.ConnectorId)

--- a/src/PostyFox.Infrastructure/Persistence/Migrations/20260812084249_AddConnectorDestinations.Designer.cs
+++ b/src/PostyFox.Infrastructure/Persistence/Migrations/20260812084249_AddConnectorDestinations.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using PostyFox.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using PostyFox.Infrastructure.Persistence;
 namespace PostyFox.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260812084249_AddConnectorDestinations")]
+    partial class AddConnectorDestinations
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/PostyFox.Infrastructure/Persistence/Migrations/20260812084249_AddConnectorDestinations.cs
+++ b/src/PostyFox.Infrastructure/Persistence/Migrations/20260812084249_AddConnectorDestinations.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PostyFox.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddConnectorDestinations : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "TargetId",
+                table: "post_targets",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "TargetName",
+                table: "post_targets",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "connector_destinations",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ConnectorId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ExternalId = table.Column<string>(type: "text", nullable: false),
+                    Name = table.Column<string>(type: "text", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_connector_destinations", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_connector_destinations_user_connectors_ConnectorId",
+                        column: x => x.ConnectorId,
+                        principalTable: "user_connectors",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_connector_destinations_ConnectorId",
+                table: "connector_destinations",
+                column: "ConnectorId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_connector_destinations_ConnectorId_ExternalId",
+                table: "connector_destinations",
+                columns: new[] { "ConnectorId", "ExternalId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "connector_destinations");
+
+            migrationBuilder.DropColumn(
+                name: "TargetId",
+                table: "post_targets");
+
+            migrationBuilder.DropColumn(
+                name: "TargetName",
+                table: "post_targets");
+        }
+    }
+}

--- a/tests/PostyFox.Application.Tests/ConnectorDestinationServiceTests.cs
+++ b/tests/PostyFox.Application.Tests/ConnectorDestinationServiceTests.cs
@@ -1,0 +1,149 @@
+using PostyFox.Application.Connectors;
+using PostyFox.Application.Dtos;
+using PostyFox.Application.Services;
+using PostyFox.Application.Tests.Support;
+using PostyFox.Domain.Entities;
+using Xunit;
+
+namespace PostyFox.Application.Tests;
+
+public class ConnectorDestinationServiceTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 7, 23, 0, 0, 0, TimeSpan.Zero);
+
+    private static async Task<Guid> SeedConnectorAsync(TestDbContext db, string userId, string platform = "Telegram", bool enabled = true)
+    {
+        if (!db.ServiceDefinitions.Any(s => s.Id == platform))
+            db.ServiceDefinitions.Add(new ServiceDefinition { Id = platform, Name = platform, Platform = platform, Enabled = true });
+        var id = Guid.NewGuid();
+        db.UserConnectors.Add(new UserConnector
+        {
+            Id = id, UserId = userId, ServiceDefinitionId = platform, DisplayName = platform, Enabled = enabled
+        });
+        await db.SaveChangesAsync();
+        return id;
+    }
+
+    private static ConnectorDestinationService New(TestDbContext db, FakeRegistry registry) =>
+        new(db, new FixedClock(Now), registry);
+
+    [Fact]
+    public async Task ListAsync_returns_null_when_connector_is_not_the_users()
+    {
+        using var db = TestDbContext.Create();
+        var connectorId = await SeedConnectorAsync(db, "owner");
+        var svc = New(db, new FakeRegistry(new FakeConnector("Telegram")));
+
+        var result = await svc.ListAsync("someone-else", connectorId);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task SetAsync_adds_new_destinations()
+    {
+        using var db = TestDbContext.Create();
+        var connectorId = await SeedConnectorAsync(db, "u1");
+        var svc = New(db, new FakeRegistry(new FakeMultiTargetConnector("Telegram")));
+
+        var result = await svc.SetAsync("u1", connectorId, [
+            new ConnectorDestinationInput("-100111", "Channel A"),
+            new ConnectorDestinationInput("-100222", "Channel B")
+        ]);
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result!.Count);
+        Assert.Contains(result, d => d.ExternalId == "-100111" && d.Name == "Channel A");
+        Assert.Contains(result, d => d.ExternalId == "-100222" && d.Name == "Channel B");
+    }
+
+    [Fact]
+    public async Task SetAsync_removes_destinations_no_longer_selected()
+    {
+        using var db = TestDbContext.Create();
+        var connectorId = await SeedConnectorAsync(db, "u1");
+        var svc = New(db, new FakeRegistry(new FakeMultiTargetConnector("Telegram")));
+        await svc.SetAsync("u1", connectorId, [
+            new ConnectorDestinationInput("-100111", "Channel A"),
+            new ConnectorDestinationInput("-100222", "Channel B")
+        ]);
+
+        var result = await svc.SetAsync("u1", connectorId, [
+            new ConnectorDestinationInput("-100111", "Channel A")
+        ]);
+
+        Assert.NotNull(result);
+        var only = Assert.Single(result!);
+        Assert.Equal("-100111", only.ExternalId);
+    }
+
+    [Fact]
+    public async Task SetAsync_updates_the_name_of_an_existing_destination()
+    {
+        using var db = TestDbContext.Create();
+        var connectorId = await SeedConnectorAsync(db, "u1");
+        var svc = New(db, new FakeRegistry(new FakeMultiTargetConnector("Telegram")));
+        await svc.SetAsync("u1", connectorId, [new ConnectorDestinationInput("-100111", "Old Name")]);
+
+        var result = await svc.SetAsync("u1", connectorId, [new ConnectorDestinationInput("-100111", "New Name")]);
+
+        Assert.NotNull(result);
+        var only = Assert.Single(result!);
+        Assert.Equal("New Name", only.Name);
+    }
+
+    [Fact]
+    public async Task SetAsync_returns_null_when_connector_does_not_support_multiple_targets()
+    {
+        using var db = TestDbContext.Create();
+        var connectorId = await SeedConnectorAsync(db, "u1", "DiscordWH");
+        var svc = New(db, new FakeRegistry(new FakeConnector("DiscordWH"))); // SupportsMultipleTargets: false
+
+        var result = await svc.SetAsync("u1", connectorId, [new ConnectorDestinationInput("x", "y")]);
+
+        Assert.Null(result);
+        Assert.Empty(db.ConnectorDestinations);
+    }
+
+    [Fact]
+    public async Task SetAsync_returns_null_when_connector_is_not_the_users()
+    {
+        using var db = TestDbContext.Create();
+        var connectorId = await SeedConnectorAsync(db, "owner");
+        var svc = New(db, new FakeRegistry(new FakeMultiTargetConnector("Telegram")));
+
+        var result = await svc.SetAsync("someone-else", connectorId, [new ConnectorDestinationInput("x", "y")]);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ListAllAsync_flattens_destinations_across_connectors_with_platform_and_display_name()
+    {
+        using var db = TestDbContext.Create();
+        var connectorId = await SeedConnectorAsync(db, "u1");
+        var svc = New(db, new FakeRegistry(new FakeMultiTargetConnector("Telegram")));
+        await svc.SetAsync("u1", connectorId, [new ConnectorDestinationInput("-100111", "Channel A")]);
+
+        var all = await svc.ListAllAsync("u1");
+
+        var only = Assert.Single(all);
+        Assert.Equal("Telegram", only.Platform);
+        Assert.Equal(connectorId, only.ConnectorId);
+        Assert.Equal("-100111", only.ExternalId);
+        Assert.Equal("Channel A", only.Name);
+    }
+
+    [Fact]
+    public async Task ListAllAsync_excludes_other_users_destinations()
+    {
+        using var db = TestDbContext.Create();
+        var connectorId = await SeedConnectorAsync(db, "u1");
+        var svc = New(db, new FakeRegistry(new FakeMultiTargetConnector("Telegram")));
+        await svc.SetAsync("u1", connectorId, [new ConnectorDestinationInput("-100111", "Channel A")]);
+
+        var all = await svc.ListAllAsync("someone-else");
+
+        Assert.Empty(all);
+    }
+}

--- a/tests/PostyFox.Application.Tests/PostIntakeServiceTests.cs
+++ b/tests/PostyFox.Application.Tests/PostIntakeServiceTests.cs
@@ -92,4 +92,68 @@ public class PostIntakeServiceTests
         Assert.NotNull(published.Delay);
         Assert.Equal(TimeSpan.FromHours(2), published.Delay!.Value);
     }
+
+    [Fact]
+    public async Task Create_resolves_a_connector_destination_selection_to_its_chat_id()
+    {
+        using var db = TestDbContext.Create();
+        db.ServiceDefinitions.Add(new ServiceDefinition { Id = "Telegram", Name = "Telegram", Platform = "Telegram", Enabled = true });
+        var connectorId = Guid.NewGuid();
+        db.UserConnectors.Add(new UserConnector
+        {
+            Id = connectorId, UserId = "u1", ServiceDefinitionId = "Telegram", DisplayName = "Telegram", Enabled = true
+        });
+        var destinationId = Guid.NewGuid();
+        db.ConnectorDestinations.Add(new ConnectorDestination
+        {
+            Id = destinationId, ConnectorId = connectorId, ExternalId = "-100111", Name = "Channel A"
+        });
+        await db.SaveChangesAsync();
+        var bus = new FakeBus();
+        var svc = new PostIntakeService(db, new FakeObjectStore(), bus, new FixedClock(DateTimeOffset.UnixEpoch),
+            new FakeRegistry(new FakeMultiTargetConnector("Telegram")),
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions()));
+
+        var result = await svc.CreateAsync("u1", new CreatePostRequest(
+            [destinationId], "Title", "Body", null, null, null, null, null, null));
+
+        Assert.NotNull(result);
+        var target = Assert.Single(db.PostTargets);
+        Assert.Equal(connectorId, target.ConnectorId);
+        Assert.Equal("-100111", target.TargetId);
+        Assert.Equal("Channel A", target.TargetName);
+    }
+
+    [Fact]
+    public async Task Create_resolves_mixed_connector_and_destination_selections_into_separate_targets()
+    {
+        using var db = TestDbContext.Create();
+        var discordId = await SeedConnectorAsync(db, "u1");
+        db.ServiceDefinitions.Add(new ServiceDefinition { Id = "Telegram", Name = "Telegram", Platform = "Telegram", Enabled = true });
+        var telegramConnectorId = Guid.NewGuid();
+        db.UserConnectors.Add(new UserConnector
+        {
+            Id = telegramConnectorId, UserId = "u1", ServiceDefinitionId = "Telegram", DisplayName = "Telegram", Enabled = true
+        });
+        var destinationId = Guid.NewGuid();
+        db.ConnectorDestinations.Add(new ConnectorDestination
+        {
+            Id = destinationId, ConnectorId = telegramConnectorId, ExternalId = "-100111", Name = "Channel A"
+        });
+        await db.SaveChangesAsync();
+        var bus = new FakeBus();
+        var svc = new PostIntakeService(db, new FakeObjectStore(), bus, new FixedClock(DateTimeOffset.UnixEpoch),
+            new FakeRegistry(new FakeConnector("DiscordWH"), new FakeMultiTargetConnector("Telegram")),
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions()));
+
+        var result = await svc.CreateAsync("u1", new CreatePostRequest(
+            [discordId, destinationId], "Title", "Body", null, null, null, null, null, null));
+
+        Assert.NotNull(result);
+        Assert.Equal(2, db.PostTargets.Count());
+        var discordTarget = db.PostTargets.Single(t => t.ConnectorId == discordId);
+        Assert.Null(discordTarget.TargetId);
+        var telegramTarget = db.PostTargets.Single(t => t.ConnectorId == telegramConnectorId);
+        Assert.Equal("-100111", telegramTarget.TargetId);
+    }
 }

--- a/tests/PostyFox.Application.Tests/PostStatusServiceGetContentTests.cs
+++ b/tests/PostyFox.Application.Tests/PostStatusServiceGetContentTests.cs
@@ -1,0 +1,106 @@
+using PostyFox.Application.Options;
+using PostyFox.Application.Posting;
+using PostyFox.Application.Tests.Support;
+using PostyFox.Domain.Entities;
+using PostyFox.Domain.Enums;
+using Xunit;
+
+namespace PostyFox.Application.Tests;
+
+/// <summary>
+/// Covers "post again" re-selection: GetContentAsync must resolve a delivered PostTarget's chat id
+/// back to the ConnectorDestination the compose form originally selected, not just its connector.
+/// </summary>
+public class PostStatusServiceGetContentTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 7, 23, 0, 0, 0, TimeSpan.Zero);
+
+    private static PostStatusService New(TestDbContext db) =>
+        new(db, new FixedClock(Now), Microsoft.Extensions.Options.Options.Create(new RetentionOptions()));
+
+    [Fact]
+    public async Task Content_resolves_target_id_back_to_the_originally_selected_destination()
+    {
+        using var db = TestDbContext.Create();
+        var connectorId = Guid.NewGuid();
+        db.UserConnectors.Add(new UserConnector
+        {
+            Id = connectorId, UserId = "u1", ServiceDefinitionId = "Telegram", DisplayName = "Telegram", Enabled = true
+        });
+        var destinationId = Guid.NewGuid();
+        db.ConnectorDestinations.Add(new ConnectorDestination
+        {
+            Id = destinationId, ConnectorId = connectorId, ExternalId = "-100111", Name = "Channel A"
+        });
+        var post = new Post { Id = Guid.NewGuid(), UserId = "u1", Title = "t", RootStatus = PostRootStatus.Delivered, CreatedAt = Now, UpdatedAt = Now };
+        post.Targets.Add(new PostTarget
+        {
+            Id = Guid.NewGuid(), ConnectorId = connectorId, Platform = "Telegram", TargetId = "-100111",
+            Status = TargetStatus.Delivered, CreatedAt = Now
+        });
+        db.Posts.Add(post);
+        await db.SaveChangesAsync();
+
+        var content = await New(db).GetContentAsync("u1", post.Id);
+
+        Assert.NotNull(content);
+        Assert.Equal([destinationId], content!.ConnectorIds);
+    }
+
+    [Fact]
+    public async Task Content_falls_back_to_the_connector_when_the_destination_is_no_longer_exposed()
+    {
+        using var db = TestDbContext.Create();
+        var connectorId = Guid.NewGuid();
+        db.UserConnectors.Add(new UserConnector
+        {
+            Id = connectorId, UserId = "u1", ServiceDefinitionId = "Telegram", DisplayName = "Telegram", Enabled = true
+        });
+        // No ConnectorDestination seeded — it has since been un-exposed.
+        var post = new Post { Id = Guid.NewGuid(), UserId = "u1", Title = "t", RootStatus = PostRootStatus.Delivered, CreatedAt = Now, UpdatedAt = Now };
+        post.Targets.Add(new PostTarget
+        {
+            Id = Guid.NewGuid(), ConnectorId = connectorId, Platform = "Telegram", TargetId = "-100111",
+            Status = TargetStatus.Delivered, CreatedAt = Now
+        });
+        db.Posts.Add(post);
+        await db.SaveChangesAsync();
+
+        var content = await New(db).GetContentAsync("u1", post.Id);
+
+        Assert.NotNull(content);
+        Assert.Equal([connectorId], content!.ConnectorIds);
+    }
+
+    [Fact]
+    public async Task Content_keys_target_options_by_the_resolved_destination_id()
+    {
+        using var db = TestDbContext.Create();
+        var connectorId = Guid.NewGuid();
+        db.UserConnectors.Add(new UserConnector
+        {
+            Id = connectorId, UserId = "u1", ServiceDefinitionId = "Telegram", DisplayName = "Telegram", Enabled = true
+        });
+        var destinationId = Guid.NewGuid();
+        db.ConnectorDestinations.Add(new ConnectorDestination
+        {
+            Id = destinationId, ConnectorId = connectorId, ExternalId = "-100111", Name = "Channel A"
+        });
+        var post = new Post { Id = Guid.NewGuid(), UserId = "u1", Title = "t", RootStatus = PostRootStatus.Delivered, CreatedAt = Now, UpdatedAt = Now };
+        post.Targets.Add(new PostTarget
+        {
+            Id = Guid.NewGuid(), ConnectorId = connectorId, Platform = "Telegram", TargetId = "-100111",
+            OptionsJson = """{"Silent":"true"}""",
+            Status = TargetStatus.Delivered, CreatedAt = Now
+        });
+        db.Posts.Add(post);
+        await db.SaveChangesAsync();
+
+        var content = await New(db).GetContentAsync("u1", post.Id);
+
+        Assert.NotNull(content);
+        var options = Assert.Single(content!.TargetOptions);
+        Assert.Equal(destinationId, options.Key);
+        Assert.Equal("true", options.Value["Silent"]);
+    }
+}

--- a/tests/PostyFox.Application.Tests/Support/Fakes.cs
+++ b/tests/PostyFox.Application.Tests/Support/Fakes.cs
@@ -64,6 +64,17 @@ public sealed class FakeConnectorWithMediaSpec(string platform, MediaSpec mediaS
         => Task.FromResult(DeliveryResult.Ok("ext-1"));
 }
 
+/// <summary>A connector for platforms exposing multiple user-selectable destinations (e.g. Telegram).</summary>
+public sealed class FakeMultiTargetConnector(string platform) : IConnector
+{
+    public ConnectorDescriptor Describe() => new(platform, platform, true, false, false, null, SupportsMultipleTargets: true);
+    public Task<AuthState> IsAuthenticatedAsync(ConnectorContext c, CancellationToken t = default) => Task.FromResult(new AuthState(true));
+    public Task<IReadOnlyList<ConnectorTarget>> ListTargetsAsync(ConnectorContext c, CancellationToken t = default)
+        => Task.FromResult<IReadOnlyList<ConnectorTarget>>([]);
+    public Task<DeliveryResult> DeliverAsync(ConnectorContext c, RenderedPost post, CancellationToken t = default)
+        => Task.FromResult(DeliveryResult.Ok("ext-1"));
+}
+
 /// <summary>A connector that authenticates from a handed-over website session (see FurAffinity).</summary>
 public sealed class FakeCookiePairingConnector(string platform, params string[] cookieNames) : IConnector
 {

--- a/tests/PostyFox.Application.Tests/Support/TestDbContext.cs
+++ b/tests/PostyFox.Application.Tests/Support/TestDbContext.cs
@@ -12,6 +12,7 @@ public sealed class TestDbContext(DbContextOptions<TestDbContext> options) : DbC
     public DbSet<ServiceDefinition> ServiceDefinitions => Set<ServiceDefinition>();
     public DbSet<UserConnector> UserConnectors => Set<UserConnector>();
     public DbSet<ConnectorCookiePairing> ConnectorCookiePairings => Set<ConnectorCookiePairing>();
+    public DbSet<ConnectorDestination> ConnectorDestinations => Set<ConnectorDestination>();
     public DbSet<Template> Templates => Set<Template>();
     public DbSet<ExternalTrigger> ExternalTriggers => Set<ExternalTrigger>();
     public DbSet<ExternalInterest> ExternalInterests => Set<ExternalInterest>();
@@ -25,6 +26,7 @@ public sealed class TestDbContext(DbContextOptions<TestDbContext> options) : DbC
         b.Entity<WebhookDedupe>().HasKey(x => new { x.Source, x.MessageId });
         b.Entity<UserConnector>().HasOne(x => x.ServiceDefinition).WithMany().HasForeignKey(x => x.ServiceDefinitionId);
         b.Entity<ConnectorCookiePairing>().HasKey(x => x.TokenHash);
+        b.Entity<ConnectorDestination>().HasOne(x => x.Connector).WithMany().HasForeignKey(x => x.ConnectorId);
     }
 
     public static TestDbContext Create()

--- a/tests/PostyFox.Infrastructure.Tests/BlobSessionStoreTests.cs
+++ b/tests/PostyFox.Infrastructure.Tests/BlobSessionStoreTests.cs
@@ -1,0 +1,67 @@
+using PostyFox.Infrastructure.Connectors;
+using PostyFox.Infrastructure.Tests.Support;
+using Xunit;
+
+namespace PostyFox.Infrastructure.Tests;
+
+/// <summary>
+/// WTelegramClient's Session.Save() persists state via Position/Write/SetLength and never calls
+/// Stream.Flush() — these tests guard against regressing to a Flush()-based persistence trigger,
+/// which silently drops all Telegram session state (see BlobSessionStore remarks).
+/// </summary>
+public class BlobSessionStoreTests
+{
+    [Fact]
+    public async Task Write_PersistsToObjectStoreImmediately_WithoutFlush()
+    {
+        var store = new FakeObjectStore();
+        var session = await BlobSessionStore.OpenAsync(store, "user-1");
+
+        var payload = new byte[] { 1, 2, 3, 4 };
+        session.Write(payload, 0, payload.Length);
+        // Deliberately do NOT call session.Flush() — WTelegramClient never does either.
+
+        Assert.True(await store.ExistsAsync("telegram", "user-1"));
+        var persisted = await store.GetTextAsync("telegram", "user-1");
+        Assert.NotEmpty(persisted);
+    }
+
+    [Fact]
+    public async Task SetLength_PersistsTruncatedState()
+    {
+        var store = new FakeObjectStore();
+        var session = await BlobSessionStore.OpenAsync(store, "user-2");
+
+        var payload = new byte[] { 1, 2, 3, 4, 5, 6 };
+        session.Write(payload, 0, payload.Length);
+        session.SetLength(2);
+
+        using var persisted = await store.GetAsync("telegram", "user-2");
+        using var ms = new MemoryStream();
+        await persisted.CopyToAsync(ms);
+        Assert.Equal(2, ms.Length);
+    }
+
+    [Fact]
+    public async Task OpenAsync_LoadsExistingSessionBytes()
+    {
+        var store = new FakeObjectStore();
+        store.Seed("telegram", "user-3", [9, 8, 7]);
+
+        var session = await BlobSessionStore.OpenAsync(store, "user-3");
+
+        Assert.Equal(3, session.Length);
+        Assert.Equal(0, session.Position);
+    }
+
+    [Fact]
+    public async Task Flush_IsANoOp_AndDoesNotThrow()
+    {
+        var store = new FakeObjectStore();
+        var session = await BlobSessionStore.OpenAsync(store, "user-4");
+
+        session.Flush();
+
+        Assert.False(await store.ExistsAsync("telegram", "user-4"));
+    }
+}

--- a/tests/PostyFox.Infrastructure.Tests/TelegramConnectorTests.cs
+++ b/tests/PostyFox.Infrastructure.Tests/TelegramConnectorTests.cs
@@ -52,4 +52,13 @@ public class TelegramConnectorTests
         // The connector must hand the gateway Telegram's declared media spec, so bytes get normalized.
         Assert.Same(PostyFox.Infrastructure.Media.PlatformMediaSpecs.Telegram, gw.LastMediaSpec);
     }
+
+    [Fact]
+    public void Describe_reports_platform_and_media_support()
+    {
+        var d = new TelegramConnector(new FakeTelegramGateway()).Describe();
+        Assert.Equal("Telegram", d.Platform);
+        Assert.True(d.SupportsMedia);
+        Assert.Same(PostyFox.Infrastructure.Media.PlatformMediaSpecs.Telegram, d.MediaSpec);
+    }
 }

--- a/tests/PostyFox.Worker.Posting.Tests/PipelineTests.cs
+++ b/tests/PostyFox.Worker.Posting.Tests/PipelineTests.cs
@@ -225,5 +225,36 @@ public class PipelineTests
         Assert.Equal(0, connector.Calls);
         Assert.Empty(await h.InScopeAsync(db => db.Posts.ToListAsync()));
     }
+
+    [Fact]
+    public async Task Posting_to_a_connector_destination_resolves_target_id_and_delivers_once_per_destination()
+    {
+        var connector = new ProgrammableConnector("Telegram", succeed: true, supportsMultipleTargets: true);
+        using var h = new PipelineHarness(connector);
+        var cid = await h.SeedConnectorAsync("u1", "Telegram");
+        var chatA = await h.SeedDestinationAsync(cid, "-100111", "Channel A");
+        var chatB = await h.SeedDestinationAsync(cid, "-100222", "Channel B");
+
+        await CreatePostAsync(h, "u1", chatA, chatB);
+
+        var targets = await h.InScopeAsync(db => db.PostTargets.OrderBy(t => t.TargetId).ToListAsync());
+        Assert.Equal(2, targets.Count);
+        Assert.All(targets, t => Assert.Equal(TargetStatus.Delivered, t.Status));
+        Assert.Equal(["-100111", "-100222"], targets.Select(t => t.TargetId).OrderBy(x => x));
+        Assert.Equal(2, connector.Calls);
+    }
+
+    [Fact]
+    public async Task Delivering_to_a_destination_passes_its_chat_id_into_the_connector_context()
+    {
+        var connector = new ProgrammableConnector("Telegram", succeed: true, supportsMultipleTargets: true);
+        using var h = new PipelineHarness(connector);
+        var cid = await h.SeedConnectorAsync("u1", "Telegram");
+        var chatA = await h.SeedDestinationAsync(cid, "-100111", "Channel A");
+
+        await CreatePostAsync(h, "u1", chatA);
+
+        Assert.Equal("-100111", connector.LastTargetId);
+    }
 }
 

--- a/tests/PostyFox.Worker.Posting.Tests/Support/PipelineHarness.cs
+++ b/tests/PostyFox.Worker.Posting.Tests/Support/PipelineHarness.cs
@@ -33,22 +33,25 @@ public sealed class FakeObjectStore : IObjectStore
     public Task DeleteAsync(string c, string k, CancellationToken t = default) => Task.CompletedTask;
 }
 
-public sealed class ProgrammableConnector(string platform, bool succeed, string? postOptionsSchema = null) : IConnector
+public sealed class ProgrammableConnector(string platform, bool succeed, string? postOptionsSchema = null, bool supportsMultipleTargets = false) : IConnector
 {
     public int Calls { get; private set; }
     public ConnectorDescriptor Describe() =>
-        new(platform, platform, true, false, false, null, PostOptionsSchema: postOptionsSchema);
+        new(platform, platform, true, false, false, null, PostOptionsSchema: postOptionsSchema, SupportsMultipleTargets: supportsMultipleTargets);
     public Task<AuthState> IsAuthenticatedAsync(ConnectorContext c, CancellationToken t = default) => Task.FromResult(new AuthState(true));
     public Task<IReadOnlyList<ConnectorTarget>> ListTargetsAsync(ConnectorContext c, CancellationToken t = default)
         => Task.FromResult<IReadOnlyList<ConnectorTarget>>([]);
     public int LastMediaCount { get; private set; }
     /// <summary>The config the pipeline resolved for the last delivery (account config + post options).</summary>
     public string? LastConfigJson { get; private set; }
+    /// <summary>The destination (chat/channel) id the pipeline resolved for the last delivery, if any.</summary>
+    public string? LastTargetId { get; private set; }
     public Task<DeliveryResult> DeliverAsync(ConnectorContext c, RenderedPost post, CancellationToken t = default)
     {
         Calls++;
         LastMediaCount = post.Media.Count;
         LastConfigJson = c.ConfigJson;
+        LastTargetId = c.TargetId;
         return Task.FromResult(succeed ? DeliveryResult.Ok($"ext-{Calls}", "http://x") : DeliveryResult.Fail("boom"));
     }
 }
@@ -92,6 +95,19 @@ public sealed class PipelineHarness : IDisposable
         {
             Id = id, UserId = userId, ServiceDefinitionId = platform, DisplayName = platform,
             ConfigJson = configJson, Enabled = enabled
+        });
+        await db.SaveChangesAsync();
+        return id;
+    }
+
+    public async Task<Guid> SeedDestinationAsync(Guid connectorId, string externalId, string name)
+    {
+        using var scope = Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var id = Guid.NewGuid();
+        db.ConnectorDestinations.Add(new ConnectorDestination
+        {
+            Id = id, ConnectorId = connectorId, ExternalId = externalId, Name = name
         });
         await db.SaveChangesAsync();
         return id;


### PR DESCRIPTION
Closes #296 
Closes #295 

Telegram can post to multiple targets, targets can be selected without needing to know the ID, or needing to register multiple connectors. Media handling fixes. And Telegram *works*